### PR TITLE
Fix-LoginSessionExpire

### DIFF
--- a/VibeTrip/Services/APIClient.swift
+++ b/VibeTrip/Services/APIClient.swift
@@ -282,7 +282,8 @@ final class APIClient: APIClientProtocol {
 
         switch refreshResult {
         case .expired:
-            // refreshToken 만료 확인: 세션 만료 발행 후 에러
+            // refreshToken 만료 확인: 만료 토큰 삭제 후 세션 만료 발행
+            try? keychain.clear()
             sessionExpiredSubject.send()
             throw APIClientError.sessionExpired
         case .transientError:

--- a/VibeTrip/Services/APIClient.swift
+++ b/VibeTrip/Services/APIClient.swift
@@ -150,6 +150,15 @@ protocol APIClientProtocol {
     var sessionExpiredPublisher: AnyPublisher<Void, Never> { get }
 }
 
+// MARK: - RefreshResult
+
+// 토큰 갱신 결과: 갱신 성공 / 진짜 만료 / 일시 오류 구분
+private enum RefreshResult {
+    case success          // 갱신 성공
+    case expired          // 서버 401/403: 진짜 만료 -> 로그아웃
+    case transientError   // 네트워크 오류, 5xx 등: 일시 오류 -> 로그아웃X
+}
+
 // MARK: - RefreshActor
 
 // Swift actor: 토큰 갱신 중복 요청을 방지

--- a/VibeTrip/Services/APIClient.swift
+++ b/VibeTrip/Services/APIClient.swift
@@ -276,14 +276,20 @@ final class APIClient: APIClientProtocol {
         }
 
         // 401: RefreshActor로 갱신 중복 방지하며 토큰 갱신
-        let refreshed = await refreshActor.refreshIfNeeded { [weak self] in
-            await self?.refreshToken() ?? false
+        let refreshResult = await refreshActor.refreshIfNeeded { [weak self] in
+            await self?.refreshToken() ?? .expired
         }
 
-        guard refreshed else {
-            // refreshToken도 만료: 세션 만료 발행 후 에러
+        switch refreshResult {
+        case .expired:
+            // refreshToken 만료 확인: 세션 만료 발행 후 에러
             sessionExpiredSubject.send()
             throw APIClientError.sessionExpired
+        case .transientError:
+            // 네트워크/서버 일시 오류: 로그아웃 없이 에러만 전파
+            throw APIClientError.networkError(URLError(.networkConnectionLost))
+        case .success:
+            break
         }
 
         // 갱신 성공: 새 accessToken으로 헤더만 교체 후 재시도

--- a/VibeTrip/Services/APIClient.swift
+++ b/VibeTrip/Services/APIClient.swift
@@ -307,22 +307,32 @@ final class APIClient: APIClientProtocol {
     // MARK: - 토큰 갱신
 
     // POST /api/v1/auth/refresh 호출: 성공 시 새 토큰 Keychain 저장
-    private func refreshToken() async -> Bool {
-        guard let refreshToken = try? keychain.getRefreshToken() else { return false }
+    private func refreshToken() async -> RefreshResult {
+        guard let refreshToken = try? keychain.getRefreshToken() else { return .expired }
 
         let endpoint = APIEndpoint(path: "/api/v1/auth/refresh", method: .post, requiresAuth: false)
-        guard var request = try? buildJSONRequest(endpoint) else { return false }
+        guard var request = try? buildJSONRequest(endpoint) else { return .transientError }
 
         // 갱신 요청: accessToken 대신 refreshToken 사용
         request.setValue("Bearer \(refreshToken)", forHTTPHeaderField: "Authorization")
 
-        guard let (data, _) = try? await session.data(for: request),
-              let apiResponse = try? JSONDecoder().decode(ApiResponse<AuthToken>.self, from: data),
+        guard let (data, response) = try? await session.data(for: request) else {
+            return .transientError  // 네트워크 오류
+        }
+
+        // 서버 401/403: refreshToken 자체가 만료된 것으로 판단
+        if let httpResponse = response as? HTTPURLResponse,
+           httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+            return .expired
+        }
+
+        // 디코딩 실패, resultType != SUCCESS, 5xx 등: 일시 오류로 판단
+        guard let apiResponse = try? JSONDecoder().decode(ApiResponse<AuthToken>.self, from: data),
               apiResponse.resultType == "SUCCESS",
-              let newToken = apiResponse.data else { return false }
+              let newToken = apiResponse.data else { return .transientError }
 
         try? keychain.save(accessToken: newToken.accessToken, refreshToken: newToken.refreshToken)
-        return true
+        return .success
     }
 
     // MARK: - URLRequest 생성 (JSON)

--- a/VibeTrip/Services/APIClient.swift
+++ b/VibeTrip/Services/APIClient.swift
@@ -169,9 +169,9 @@ private actor RefreshActor {
     private var isRefreshing = false
 
     // 갱신 완료를 기다리는 요청 대기열
-    private var waiters: [CheckedContinuation<Bool, Never>] = []
+    private var waiters: [CheckedContinuation<RefreshResult, Never>] = []
 
-    func refreshIfNeeded(using action: () async -> Bool) async -> Bool {
+    func refreshIfNeeded(using action: () async -> RefreshResult) async -> RefreshResult {
         if isRefreshing {
             // 이미 갱신 진행 중 -> 완료될 때까지 대기 후 같은 결과 수신
             return await withCheckedContinuation { continuation in
@@ -180,13 +180,13 @@ private actor RefreshActor {
         }
 
         isRefreshing = true
-        let success = await action()
+        let result = await action()
 
         // 대기 중이던 요청에 갱신 결과 전달
-        for waiter in waiters { waiter.resume(returning: success) }
+        for waiter in waiters { waiter.resume(returning: result) }
         waiters.removeAll()
         isRefreshing = false
-        return success
+        return result
     }
 }
 

--- a/VibeTrip/Services/AlbumServiceProtocol.swift
+++ b/VibeTrip/Services/AlbumServiceProtocol.swift
@@ -237,6 +237,8 @@ final class MockAlbumService: AlbumServiceProtocol {
         titleFetchCount[albumId, default: 0] += 1
         guard titleFetchCount[albumId]! >= titleReadyAfterAttempts else { return nil }
         return "Mock 앨범 타이틀"
+    }
+
     func deleteAlbumLog(albumId: String, albumLogId: Int) async throws {
         try await Task.sleep(nanoseconds: delay)
         if let error = simulatedError { throw error }

--- a/VibeTrip/Views/LoginView.swift
+++ b/VibeTrip/Views/LoginView.swift
@@ -264,10 +264,11 @@ private struct SafariView: UIViewControllerRepresentable {
 
 #if DEBUG
 #Preview {
-    let appState = AppState()
-    appState.toastPayload = AppToastPayload(message: "로그아웃이 완료되었습니다", systemImageName: nil)
-
+    @Previewable @StateObject var appState = AppState()
     LoginView()
         .environmentObject(appState)
+        .onAppear {
+            appState.toastPayload = AppToastPayload(message: "로그아웃이 완료되었습니다", systemImageName: nil)
+        }
 }
 #endif

--- a/VibeTrip/Views/MainPageView.swift
+++ b/VibeTrip/Views/MainPageView.swift
@@ -58,13 +58,12 @@ struct MainPageView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .task { await viewModel.loadAlbums() }
-.onDisappear { viewModel.cancelAllPolling() }
+        .onDisappear { viewModel.cancelAllPolling() }
         .onChange(of: appState.needsAlbumRefresh) { _, needsReload in
             guard needsReload else { return }
             // 중복 트리거 방지를 위해 플래그 먼저 초기화 후 새로고침
             appState.needsAlbumRefresh = false
             Task { await viewModel.reloadAlbums() }
-        }
         }
         .fullScreenCover(item: $selectedAlbum) { album in
             AlbumDetailView(
@@ -342,6 +341,5 @@ private extension AlbumCard {
     service.titleReadyAfterAttempts = 2  // 4번째 카드: 2번째 폴링(약 5초)에서 타이틀 반환
     return MainPageView(viewModel: MainPageViewModel(albumService: service))
         .environmentObject(AppState())
-}
 }
 #endif

--- a/VibeTripTests/APIClientTests.swift
+++ b/VibeTripTests/APIClientTests.swift
@@ -198,37 +198,66 @@ final class APIClientTests: XCTestCase {
     }
     
     // MARK: - 401 -> 토큰 갱신 실패 -> 세션 만료
-    
-    // 갱신 실패 시 sessionExpiredPublisher 발행 + APIClientError.sessionExpired throw
-    func test_401_refreshFailed_publishesSessionExpiredAndThrows() async throws {
+
+    // 갱신 요청에서 서버 401 반환 시 sessionExpiredPublisher 발행 + APIClientError.sessionExpired throw
+    func test_401_refreshExpired_publishesSessionExpiredAndThrows() async throws {
         // 1. 원래 요청: 401
-        // 2. 갱신 요청: 실패 응답
-        let unauthorizedResponse = makeHTTPResponse(statusCode: 401)
-        let refreshFailData = try makeErrorResponse(code: "E2002", message: "토큰 만료")
-        
+        // 2. 갱신 요청: 서버 401 -> refreshToken 만료 확인
         mockSession.responses = [
-            (Data(), unauthorizedResponse),
-            (refreshFailData, makeHTTPResponse(statusCode: 200))
+            (Data(), makeHTTPResponse(statusCode: 401)),
+            (Data(), makeHTTPResponse(statusCode: 401))
         ]
-        
+
         // sessionExpiredPublisher 발행 여부 추적
         var sessionExpiredFired = false
         sut.sessionExpiredPublisher
             .sink { sessionExpiredFired = true }
             .store(in: &cancellables)
-        
+
         let endpoint = APIEndpoint(path: "/api/v1/test", method: .get)
-        
+
         do {
             let _: SampleResponse = try await sut.request(endpoint)
             XCTFail("sessionExpired 에러가 throw되어야 합니다")
         } catch APIClientError.sessionExpired {
             XCTAssertTrue(sessionExpiredFired, "sessionExpiredPublisher가 발행되어야 합니다")
+            // 만료된 토큰이 Keychain에서 삭제됐는지 확인
+            XCTAssertNil(mockKeychain.accessToken, "세션 만료 시 accessToken이 삭제되어야 합니다")
+            XCTAssertNil(mockKeychain.refreshToken, "세션 만료 시 refreshToken이 삭제되어야 합니다")
         } catch {
             XCTFail("예상치 못한 에러: \(error)")
         }
     }
-    
+
+    // MARK: - 401 -> 갱신 일시 오류 -> 로그아웃 없이 네트워크 에러
+
+    // 갱신 요청에서 서버 5xx 반환 시 -> sessionExpiredPublisher 미발행 + APIClientError.networkError throw
+    func test_401_refreshTransientError_doesNotPublishSessionExpired() async throws {
+        // 1. 원래 요청: 401
+        // 2. 갱신 요청: 서버 503 -> 일시 오류
+        mockSession.responses = [
+            (Data(), makeHTTPResponse(statusCode: 401)),
+            (Data(), makeHTTPResponse(statusCode: 503))
+        ]
+
+        // sessionExpiredPublisher가 발행되면 안됨
+        var sessionExpiredFired = false
+        sut.sessionExpiredPublisher
+            .sink { sessionExpiredFired = true }
+            .store(in: &cancellables)
+
+        let endpoint = APIEndpoint(path: "/api/v1/test", method: .get)
+
+        do {
+            let _: SampleResponse = try await sut.request(endpoint)
+            XCTFail("networkError가 throw되어야 합니다")
+        } catch APIClientError.networkError {
+            XCTAssertFalse(sessionExpiredFired, "일시 오류 시 sessionExpiredPublisher가 발행되면 안 됩니다")
+        } catch {
+            XCTFail("예상치 못한 에러: \(error)")
+        }
+    }
+
     // MARK: - perform (응답 바디 없는 요청)
     
     // DELETE 등 Unit 응답 -> 에러 없이 정상 완료

--- a/VibeTripTests/MainPageViewModelTests.swift
+++ b/VibeTripTests/MainPageViewModelTests.swift
@@ -73,6 +73,7 @@ private final class PollingStubAlbumService: AlbumServiceProtocol {
     func fetchAlbumLogs(albumId: String, cursor: Int?, limit: Int) async throws -> AlbumLogListPayload { fatalError("미사용") }
     func updateAlbum(albumId: String, request: AlbumUpdateRequest) async throws -> AlbumCard { fatalError("미사용") }
     func deleteAlbum(albumId: String) async throws { fatalError("미사용") }
+    func deleteAlbumLog(albumId: String, albumLogId: Int) async throws { fatalError("미사용") }
     func saveLog(request: AlbumLogRequest) async throws { fatalError("미사용") }
 }
 


### PR DESCRIPTION
## 📄 작업 내용
- 로그인 세션 비정상 만료되는 오류 수정
- 실제 토큰 만료(401or403)일 때만 로그아웃 처리되도록 갱신 실패 원인 구분
- 세션 만료로 로그아웃 시, 만료된 토큰 즉시 삭제

## 🔗 관련 이슈
<!-- ex) close #12 -->
close #47 


