### PR TITLE
Fix: 상세페이지로 딥링크 시 앨범 이미지 로드가 안되는 문제 해결(#82)

### DIFF
--- a/VibeTrip/Models/AppState.swift
+++ b/VibeTrip/Models/AppState.swift
@@ -88,6 +88,10 @@ struct AppToastPayload: Equatable {
     // MainPageView onDismiss(송신) -> MainTabBarView onChange(수신) 후 nil 초기화
     @Published var deeplinkAlbumReadyToPresent: String? = nil
 
+    // 딥링크 상세 뒤로가기 후 캐러셀을 해당 앨범 카드 위치로 이동
+    // MainTabBarView onBackTap(송신) -> MainPageView onChange(수신) 후 nil 초기화
+    @Published var pendingCarouselAlbumId: Int? = nil
+
 
     // APIClient.sessionExpiredPublisher 구독 유지용
     private var cancellables = Set<AnyCancellable>()

--- a/VibeTrip/Models/AppState.swift
+++ b/VibeTrip/Models/AppState.swift
@@ -80,6 +80,15 @@ struct AppToastPayload: Equatable {
     // 딥링크 수신 시 기존 커버 유무 판단에 사용
     @Published var isAlbumDetailPresented: Bool = false
 
+    // MainPageView 커버 dismiss 후 이동할 앨범 ID (nil: 대기 없음)
+    // MainTabBarView(송신) -> MainPageView onDismiss에서 소비 후 nil 초기화
+    @Published var pendingDeeplinkAlbumId: String? = nil
+
+    // MainPageView 커버 dismiss 완료 시 MainTabBarView로 전달하는 앨범 ID 시그널
+    // MainPageView onDismiss(송신) -> MainTabBarView onChange(수신) 후 nil 초기화
+    @Published var deeplinkAlbumReadyToPresent: String? = nil
+
+
     // APIClient.sessionExpiredPublisher 구독 유지용
     private var cancellables = Set<AnyCancellable>()
 

--- a/VibeTrip/Views/MainPageView.swift
+++ b/VibeTrip/Views/MainPageView.swift
@@ -82,7 +82,13 @@ struct MainPageView: View {
                 guard needsDismiss else { return }
                 selectedAlbum = nil
             }
-            .fullScreenCover(item: $selectedAlbum) { album in
+            .fullScreenCover(item: $selectedAlbum, onDismiss: {
+                // 딥링크로 인한 dismiss인 경우: AppState 시그널로 MainTabBarView에 알림
+                guard let albumId = appState.pendingDeeplinkAlbumId else { return }
+                appState.pendingDeeplinkAlbumId = nil
+                appState.needsDismissAlbumDetail = false
+                appState.deeplinkAlbumReadyToPresent = albumId
+            }) { album in
                 AlbumDetailView(
                     displayModel: album.toDisplayModel(),
                     onBackTap: { selectedAlbum = nil },
@@ -104,6 +110,8 @@ struct MainPageView: View {
                         appState.pendingTabNavigation = .home
                     }
                 )
+                // albumId 기준으로 view 재생성 강제 -> @State/@StateObject 확실히 초기화
+                .id(album.id)
             }
             .overlay(alignment: .bottom) {
                 if showGeneratingToast {

--- a/VibeTrip/Views/MainPageView.swift
+++ b/VibeTrip/Views/MainPageView.swift
@@ -141,8 +141,15 @@ struct MainPageView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .task { await viewModel.loadAlbums() }
         // 첫 진입 시 현재 카드 주변 이미지 캐시 적재
+        // 홈 탭 진입 시점에 대기 중인 카드 위치 이동 처리 -> onChange가 놓친 경우 보완
         .onAppear {
             preloadCoverImages(urls: preloadCoverImageURLs(from: visibleAlbums))
+            if let albumId = appState.pendingCarouselAlbumId,
+               let idx = visibleAlbums.firstIndex(where: { $0.id == albumId }) {
+                appState.pendingCarouselAlbumId = nil
+                currentIndex = idx
+                dragOffset = 0
+            }
         }
         .onDisappear { viewModel.cancelAllPolling() }
         // 스와이프 후 현재 카드가 바뀌면 주변 이미지 다시 준비
@@ -160,6 +167,14 @@ struct MainPageView: View {
             currentIndex = 0
             dragOffset = 0
             Task { await viewModel.reloadAlbums() }
+        }
+        // 딥링크 상세 뒤로가기 후 해당 앨범 카드로 캐러셀 위치 이동
+        .onChange(of: appState.pendingCarouselAlbumId) { _, albumId in
+            guard let albumId else { return }
+            appState.pendingCarouselAlbumId = nil
+            guard let idx = visibleAlbums.firstIndex(where: { $0.id == albumId }) else { return }
+            currentIndex = idx
+            dragOffset = 0
         }
     }
 

--- a/VibeTrip/Views/MainTabBarView.swift
+++ b/VibeTrip/Views/MainTabBarView.swift
@@ -74,6 +74,10 @@ struct MainTabBarView: View {
     @State private var isResolvingAlbumDetail = false
     @State private var presentedAlbumDetail: PendingAlbumDetailPresentation? = nil
 
+    // MainTabBarView 자체 커버(presentedAlbumDetail) dismiss 완료 후 진입할  albumId
+    // fullScreenCover onDismiss에서 소비
+    @State private var ownCoverPendingAlbumId: String? = nil
+
     @EnvironmentObject private var appState: AppState
     @StateObject private var notificationViewModel = NotificationViewModel()
     @StateObject private var mainPageViewModel = MainPageViewModel()
@@ -107,7 +111,12 @@ struct MainTabBarView: View {
             appState.fcmCompletedAlbumId = nil
             Task { await mainPageViewModel.handleAlbumCompleted(albumId: albumId) }
         }
-        .fullScreenCover(item: $presentedAlbumDetail) { presentation in
+        .fullScreenCover(item: $presentedAlbumDetail, onDismiss: {
+            // 딥링크로 인한 dismiss인 경우: dismiss 완료 직후 새 앨범 상세로 진입
+            guard let albumId = ownCoverPendingAlbumId else { return }
+            ownCoverPendingAlbumId = nil
+            Task { await presentAlbumDetailOverlay(albumId: albumId) }
+        }) { presentation in
             AlbumDetailView(
                 displayModel: presentation.displayModel,
                 onBackTap: {
@@ -128,6 +137,8 @@ struct MainTabBarView: View {
                     appState.needsAlbumRefresh = true
                 }
             )
+            // albumId 기준으로 view 재생성 강제 -> @State/@StateObject 확실히 초기화
+            .id(presentation.displayModel.albumId)
             .onAppear {
                 // 해당 앨범 상세페이지 이동 후 탭 전환
                 DispatchQueue.main.async {
@@ -174,12 +185,9 @@ struct MainTabBarView: View {
                     }
                 }
             case .openAlbumDetail(let albumId):
-                // 기존에 열린 상세 커버 여부를 변경 전 시점에 캡처
-                let hadOpenDetail = appState.isAlbumDetailPresented
-
-                // MainTabBarView 경유 커버 및 MainPageView 경유 커버 모두 dismiss 처리
-                presentedAlbumDetail = nil
-                appState.needsDismissAlbumDetail = true
+                // 어느 경로로 커버가 열려 있는지 각각 확인
+                let hadPresentedDetail = presentedAlbumDetail != nil         // MainTabBarView 경유
+                let hadSelectedAlbum = !hadPresentedDetail && appState.isAlbumDetailPresented  // MainPageView 경유
 
                 withAnimation(.easeInOut(duration: 0.24)) {
                     isPresentingLoadingView = false
@@ -187,15 +195,16 @@ struct MainTabBarView: View {
                     isTabBarHidden = true
                 }
 
-                if hadOpenDetail {
-                    // 기존 커버가 있었으면 dismiss 애니메이션 완료 후 새 상세 진입
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                        appState.needsDismissAlbumDetail = false
-                        Task { await presentAlbumDetailOverlay(albumId: albumId) }
-                    }
+                if hadPresentedDetail {
+                    // MainTabBarView 자체 커버가 열려 있음 -> fullScreenCover onDismiss에서 dismiss 완료 시점에 새 커버 진입
+                    ownCoverPendingAlbumId = albumId
+                    presentedAlbumDetail = nil
+                } else if hadSelectedAlbum {
+                    // MainPageView 커버가 열려 있음 -> needsDismissAlbumDetail로 dismiss 트리거, onDismiss에서 AppState 시그널 발송
+                    appState.pendingDeeplinkAlbumId = albumId
+                    appState.needsDismissAlbumDetail = true
                 } else {
-                    // 열린 커버 없으면 즉시 진입
-                    appState.needsDismissAlbumDetail = false
+                    // 열린 커버 없음 -> 즉시 진입
                     Task { await presentAlbumDetailOverlay(albumId: albumId) }
                 }
             case .openHome:
@@ -207,6 +216,12 @@ struct MainTabBarView: View {
         // presentedAlbumDetail 변화 시 AppState 동기화: 딥링크 수신 시 기존 커버 유무 판단에 사용
         .onChange(of: presentedAlbumDetail?.id) { _, detailId in
             appState.isAlbumDetailPresented = detailId != nil
+        }
+        // MainPageView 커버 dismiss 완료 시그널 수신: 새 앨범 상세로 진입
+        .onChange(of: appState.deeplinkAlbumReadyToPresent) { _, albumId in
+            guard let albumId else { return }
+            appState.deeplinkAlbumReadyToPresent = nil
+            Task { await presentAlbumDetailOverlay(albumId: albumId) }
         }
         // 앨범 삭제 등 특정 탭 이동 요청 처리
         .onChange(of: appState.pendingTabNavigation) { _, tab in

--- a/VibeTrip/Views/MainTabBarView.swift
+++ b/VibeTrip/Views/MainTabBarView.swift
@@ -120,6 +120,8 @@ struct MainTabBarView: View {
             AlbumDetailView(
                 displayModel: presentation.displayModel,
                 onBackTap: {
+                    // 뒤로가기 시 캐러셀을 해당 앨범 카드 위치로 이동
+                    appState.pendingCarouselAlbumId = presentation.displayModel.albumId
                     presentedAlbumDetail = nil
                     selectedTab = .home
                     isTabBarHidden = false


### PR DESCRIPTION
## 📄 작업 내용
- 상세 페이지에서 상세 페이지로 딥링크 시, 이미지 로드 안되는 문제 해결
- 상세 페이지로 딥링크 후 뒤로가기 시, 해당 앨범 카드가 메인 위치에 설정되도록 추가

## 🔗 관련 이슈
<!-- ex) Closes #12 -->
Closes #82 
