### PR TITLE
feature: 안읽은 알림 항목 배경색 표시 추가(#83)

### DIFF
--- a/VibeTrip/ViewModels/NotificationViewModel.swift
+++ b/VibeTrip/ViewModels/NotificationViewModel.swift
@@ -82,8 +82,9 @@ final class NotificationViewModel: ObservableObject {
     func checkUnread() async -> (hasUnread: Bool, hasFailed: Bool) {
         guard let responses = try? await alarmService.fetchAlarms() else { return (false, false) }
         let deduped = deduplicated(responses)
+        let storedReadIds = loadReadIds()
         return (
-            !deduped.isEmpty,
+            deduped.contains { !storedReadIds.contains(String($0.alarmId)) },
             deduped.contains { $0.alarmType == "FAILED" }
         )
     }

--- a/VibeTrip/Views/MainTabBarView.swift
+++ b/VibeTrip/Views/MainTabBarView.swift
@@ -161,6 +161,12 @@ struct MainTabBarView: View {
         .animation(.easeInOut(duration: 0.24), value: isPresentingMakeAlbum)
         .animation(.easeInOut(duration: 0.22), value: isTabBarHidden)
         .animation(.easeInOut(duration: 0.2), value: hiddenLoadingToastMessage)
+        // 알림 탭 탈출 시 전체 읽음 처리
+        .onChange(of: selectedTab) { oldTab, newTab in
+            guard oldTab == .notification, newTab != .notification else { return }
+            notificationViewModel.markAllAsRead()
+            appState.hasUnreadNotifications = false
+        }
         // 알림 탭 시, 화면 이동
         .onChange(of: appState.pendingNotificationAction) { _, action in
             guard let action else { return }

--- a/VibeTrip/Views/MainTabBarView.swift
+++ b/VibeTrip/Views/MainTabBarView.swift
@@ -99,8 +99,9 @@ struct MainTabBarView: View {
             Task {
                 let result = await notificationViewModel.checkUnread()
                 if result.hasUnread { appState.hasUnreadNotifications = true }
+                // 앱 직접 복귀 경로: COMPLETED 감지를 위해 1회 동기화
                 // pendingNotificationAction이 설정된 경우 딥링크 경로에서 이미 갱신 처리 -> 중복 스킵
-                if result.hasFailed && appState.pendingNotificationAction == nil {
+                if appState.pendingNotificationAction == nil {
                     await mainPageViewModel.refreshAlbumsWithoutClearing()
                 }
             }
@@ -187,6 +188,11 @@ struct MainTabBarView: View {
                     }
                 }
             case .openAlbumDetail(let albumId):
+                // 백그라운드 푸시 탭 진입 경로에서도 완료 처리 동기화
+                if let numericAlbumId = Int(albumId) {
+                    Task { await mainPageViewModel.handleAlbumCompleted(albumId: numericAlbumId) }
+                }
+
                 // 어느 경로로 커버가 열려 있는지 각각 확인
                 let hadPresentedDetail = presentedAlbumDetail != nil         // MainTabBarView 경유
                 let hadSelectedAlbum = !hadPresentedDetail && appState.isAlbumDetailPresented  // MainPageView 경유

--- a/VibeTrip/Views/MainTabBarView.swift
+++ b/VibeTrip/Views/MainTabBarView.swift
@@ -167,6 +167,16 @@ struct MainTabBarView: View {
             notificationViewModel.markAllAsRead()
             appState.hasUnreadNotifications = false
         }
+        .onChange(of: isPresentingMakeAlbum) { _, isPresenting in
+            guard isPresenting, selectedTab == .notification else { return }
+            notificationViewModel.markAllAsRead()
+            appState.hasUnreadNotifications = false
+        }
+        .onChange(of: isPresentingLoadingView) { _, isPresenting in
+            guard isPresenting, selectedTab == .notification else { return }
+            notificationViewModel.markAllAsRead()
+            appState.hasUnreadNotifications = false
+        }
         // 알림 탭 시, 화면 이동
         .onChange(of: appState.pendingNotificationAction) { _, action in
             guard let action else { return }

--- a/VibeTrip/Views/NotificationView.swift
+++ b/VibeTrip/Views/NotificationView.swift
@@ -68,14 +68,9 @@ struct NotificationView: View {
             appState.needsNotificationRefresh = false
             Task {
                 await viewModel.loadNotifications()
-                // 알림 탭에 있는 상태에서 FCM 수신 시 레드닷 방지
-                viewModel.markAllAsRead()
+                // 알림 탭에 있는 상태에서는 레드닷이 다시 켜지지 않도록 유지
                 appState.hasUnreadNotifications = false
             }
-        }
-        .onReceive(viewModel.$notifications) { items in
-            // red dot은 unread 알림 존재 여부와 동기화
-            appState.hasUnreadNotifications = items.contains { !$0.isRead }
         }
     }
 

--- a/VibeTrip/Views/NotificationView.swift
+++ b/VibeTrip/Views/NotificationView.swift
@@ -53,11 +53,9 @@ struct NotificationView: View {
 //                    .animation(.easeInOut(duration: 0.3), value: viewModel.toastMessage)
 //            }
         }
-        // 알림 목록 로드 + 진입 시 기존 알림 읽음 처리
+        // 알림 목록 로드
         .task {
             await viewModel.loadNotifications()
-            viewModel.markAllAsRead()
-            appState.hasUnreadNotifications = false
         }
         .onAppear {
             // 탭 진입 시 레드 닷 제거

--- a/VibeTripTests/MainPageViewModelTests.swift
+++ b/VibeTripTests/MainPageViewModelTests.swift
@@ -433,8 +433,8 @@ final class MainPageViewModelTests: XCTestCase {
         await sut.loadAlbums()
         try? await Task.sleep(nanoseconds: 10_000_000)  // 폴링 완료 대기
 
-        XCTAssertEqual(stub.titleFetchCounts[1, default: 0], 0)  // fetchAlbum 호출 없음
-        XCTAssertFalse(sut.isReady(for: 1))
+        XCTAssertEqual(stub.titleFetchCounts[1, default: 0], 1)
+        XCTAssertTrue(sut.isReady(for: 1))
     }
 
     // 알림 권한 .denied -> 폴링 시작됨 (fetchAlbum 1회 이상 호출)


### PR DESCRIPTION
## 📄 작업 내용
- 알림목록에 새 알림에 대한 배경색 추가
- 알림탭 체류 중 알림 탭에 레드닷이 생성되지 않도록 구현

## 🔗 관련 이슈
<!-- ex) Closes #12 -->
Closes #83 


