### PR TITLE
fix: 오류들 수정(#89)

### DIFF
--- a/VibeTrip/Models/FCMPayloadModel.swift
+++ b/VibeTrip/Models/FCMPayloadModel.swift
@@ -37,6 +37,35 @@ struct FCMPayloadErrorData: Decodable {
     let albumId: Int?
 }
 
+// MARK: - FCMPayload 디코딩
+
+extension FCMPayload {
+
+    // FCM userInfo에서 커스텀 payload 디코딩 (래핑 유무 모두 지원)
+    static func decode(from userInfo: [AnyHashable: Any]) -> FCMPayload? {
+        let decoder = JSONDecoder()
+
+        if let payloadObject = userInfo["payload"] as? [String: Any],
+           let data = try? JSONSerialization.data(withJSONObject: payloadObject),
+           let payload = try? decoder.decode(FCMPayload.self, from: data) {
+            return payload
+        }
+
+        if let payloadString = userInfo["payload"] as? String,
+           let data = payloadString.data(using: .utf8),
+           let payload = try? decoder.decode(FCMPayload.self, from: data) {
+            return payload
+        }
+
+        // payload 래핑이 없는 형식도 대비
+        if let data = try? JSONSerialization.data(withJSONObject: userInfo),
+           let payload = try? decoder.decode(FCMPayload.self, from: data) {
+            return payload
+        }
+        return nil
+    }
+}
+
 // MARK: - FCMPayload → NotificationNavigationAction 변환
 
 extension FCMPayload {

--- a/VibeTrip/VibeTripApp.swift
+++ b/VibeTrip/VibeTripApp.swift
@@ -79,7 +79,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                                 willPresent notification: UNNotification,
                                 withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         let userInfo = notification.request.content.userInfo
-        let payload = decodeFCMPayload(from: userInfo)
+        let payload = FCMPayload.decode(from: userInfo)
         Task { @MainActor in
             appState?.hasUnreadNotifications = true
             appState?.needsNotificationRefresh = true
@@ -98,37 +98,13 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                                 didReceive response: UNNotificationResponse,
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
         let userInfo = response.notification.request.content.userInfo
-        let navigationAction = decodeFCMPayload(from: userInfo)?.toNavigationAction()
+        let navigationAction = FCMPayload.decode(from: userInfo)?.toNavigationAction()
         Task { @MainActor in
             appState?.hasUnreadNotifications = true
             appState?.needsNotificationRefresh = true
             appState?.pendingNotificationAction = navigationAction
         }
         completionHandler()
-    }
-
-    // FCM userInfo에서 커스텀 payload 디코딩
-    private func decodeFCMPayload(from userInfo: [AnyHashable: Any]) -> FCMPayload? {
-        let decoder = JSONDecoder()
-
-        if let payloadObject = userInfo["payload"] as? [String: Any],
-           let data = try? JSONSerialization.data(withJSONObject: payloadObject),
-           let payload = try? decoder.decode(FCMPayload.self, from: data) {
-            return payload
-        }
-
-        if let payloadString = userInfo["payload"] as? String,
-           let data = payloadString.data(using: .utf8),
-           let payload = try? decoder.decode(FCMPayload.self, from: data) {
-            return payload
-        }
-
-        // payload 래핑이 없는 형식도 대비
-        if let data = try? JSONSerialization.data(withJSONObject: userInfo),
-           let payload = try? decoder.decode(FCMPayload.self, from: data) {
-            return payload
-        }
-        return nil
     }
 }
 

--- a/VibeTrip/ViewModels/MainPageViewModel.swift
+++ b/VibeTrip/ViewModels/MainPageViewModel.swift
@@ -171,6 +171,11 @@ final class MainPageViewModel: ObservableObject {
         for album in albums where !readyAlbumIds.contains(album.id) {
             guard pollingTasks[album.id] == nil else { continue }
             let albumId = album.id
+            // title이 있고 재생성 대기 중이 아닌 앨범: 서버에서 이미 완료된 것으로 즉시 ready 처리
+            if album.title != nil && !pendingPollingIds.contains(albumId) {
+                readyAlbumIds.insert(albumId)
+                continue
+            }
             if shouldPoll {
                 pollingTasks[albumId] = Task { [weak self] in
                     await self?.pollMusic(for: albumId)
@@ -185,21 +190,39 @@ final class MainPageViewModel: ObservableObject {
     }
 
     // 권한 있는 경우 앱 진입 시 1회만 완료 여부 확인 (이후 완료는 FCM으로 수신)
+    // 1회 확인 실패 시(서버 반영 지연 등) 반복 폴링으로 폴백 -> 영구 스켈레톤 방지
     private func checkMusicOnce(for albumId: Int) async {
-        defer { pollingTasks[albumId] = nil }
-        guard !Task.isCancelled else { return }
-        guard let detail = try? await albumService.fetchAlbum(albumId: albumId),
-              detail.musicUrl != nil else { return }
-        applyAlbumReady(title: detail.title, for: albumId)
+        guard !Task.isCancelled else {
+            pollingTasks[albumId] = nil
+            return
+        }
+        if let detail = try? await albumService.fetchAlbum(albumId: albumId),
+           detail.musicUrl != nil {
+            applyAlbumReady(title: detail.title, for: albumId)
+            return
+        }
+        // 단건 확인 실패: 반복 폴링으로 폴백
+        guard !Task.isCancelled else {
+            pollingTasks[albumId] = nil
+            return
+        }
+        await pollMusic(for: albumId)
     }
 
     // FCM COMPLETED 수신 시 호출: 기존 폴링 취소 후 fetchAlbum 1회로 완료 처리
+    // 1회 확인 실패 시(서버 replication 지연 등) 반복 폴링으로 폴백 -> 영구 스켈레톤 방지
     func handleAlbumCompleted(albumId: Int) async {
         pollingTasks[albumId]?.cancel()
         pollingTasks[albumId] = nil
-        guard let detail = try? await albumService.fetchAlbum(albumId: albumId),
-              detail.musicUrl != nil else { return }
-        applyAlbumReady(title: detail.title, for: albumId)
+        if let detail = try? await albumService.fetchAlbum(albumId: albumId),
+           detail.musicUrl != nil {
+            applyAlbumReady(title: detail.title, for: albumId)
+            return
+        }
+        // 단건 확인 실패: 반복 폴링으로 폴백
+        pollingTasks[albumId] = Task { [weak self] in
+            await self?.pollMusic(for: albumId)
+        }
     }
 
     // musicUrl 조회: 즉시 1회 확인 후 5초 간격, 최대 120회(10분)

--- a/VibeTrip/Views/Components/DateRangePickerSheetView.swift
+++ b/VibeTrip/Views/Components/DateRangePickerSheetView.swift
@@ -42,6 +42,20 @@ struct DateRangePickerSheetView: View {
         _anchorDate = State(initialValue: normalizedStartDate == normalizedEndDate ? normalizedStartDate : nil)
     }
 
+    private var calendarRowCount: Int {
+        guard let monthInterval = calendar.dateInterval(of: .month, for: displayedMonth),
+              let firstWeekInterval = calendar.dateInterval(of: .weekOfMonth, for: monthInterval.start),
+              let lastDayOfMonth = calendar.date(byAdding: .day, value: -1, to: monthInterval.end),
+              let lastWeekInterval = calendar.dateInterval(of: .weekOfMonth, for: lastDayOfMonth)
+        else { return 5 }
+        let totalDays = calendar.dateComponents([.day], from: firstWeekInterval.start, to: lastWeekInterval.end).day ?? 35
+        return totalDays / 7
+    }
+
+    private var sheetHeight: CGFloat {
+        calendarRowCount == 6 ? 650 : 590
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
             Text("여행 기간")
@@ -81,7 +95,7 @@ struct DateRangePickerSheetView: View {
         .padding(.horizontal, 20)
         .padding(.top, 28)
         .padding(.bottom, 24)
-        .presentationDetents([.height(590)])
+        .presentationDetents([.height(sheetHeight)])
     }
 }
 

--- a/VibeTrip/Views/MainPageView.swift
+++ b/VibeTrip/Views/MainPageView.swift
@@ -29,6 +29,7 @@ struct MainPageView: View {
 
     // 타이틀 생성 중 앨범 탭 시 표시하는 차단 토스트
     @State private var showGeneratingToast: Bool = false
+    @State private var generatingToastDismissTask: Task<Void, Never>? = nil
 
     // MARK: - 캐러셀 Layout Constants
 
@@ -147,7 +148,10 @@ struct MainPageView: View {
                 dragOffset = 0
             }
         }
-        .onDisappear { viewModel.cancelAllPolling() }
+        .onDisappear {
+            viewModel.cancelAllPolling()
+            generatingToastDismissTask?.cancel()
+        }
         // 스와이프 후 현재 카드가 바뀌면 주변 이미지 다시 준비
         .onChange(of: currentIndex) { _, _ in
             preloadCoverImages(urls: preloadCoverImageURLs(from: visibleAlbums))
@@ -302,12 +306,7 @@ struct MainPageView: View {
                             .onTapGesture {
                                 guard isActive else { return }
                                 if !viewModel.isReady(for: album.id) {
-                                    guard !showGeneratingToast else { return }
-                                    withAnimation { showGeneratingToast = true }
-                                    Task {
-                                        try? await Task.sleep(nanoseconds: 3_000_000_000)
-                                        withAnimation { showGeneratingToast = false }
-                                    }
+                                    showGeneratingToastWithAutoDismiss()
                                 } else {
                                     selectedAlbum = album
                                 }
@@ -387,6 +386,21 @@ struct MainPageView: View {
         }
 
         Task { await viewModel.loadMoreIfNeeded(currentIndex: currentIndex) }
+    }
+
+    // 생성 중 토스트를 항상 메인 액터에서 표시/해제
+    private func showGeneratingToastWithAutoDismiss() {
+        generatingToastDismissTask?.cancel()
+        withAnimation { showGeneratingToast = true }
+
+        generatingToastDismissTask = Task {
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            guard !Task.isCancelled else { return }
+
+            await MainActor.run {
+                withAnimation { showGeneratingToast = false }
+            }
+        }
     }
 
     private func preloadCoverImageURLs(from visibleAlbums: [AlbumCard]) -> [URL] {

--- a/VibeTrip/Views/MainTabBarView.swift
+++ b/VibeTrip/Views/MainTabBarView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import UIKit
+import UserNotifications
 
 // MARK: - AppTab
 // 탭바 항목 정의 (순서, 아이콘, 레이블)
@@ -99,6 +100,8 @@ struct MainTabBarView: View {
             Task {
                 let result = await notificationViewModel.checkUnread()
                 if result.hasUnread { appState.hasUnreadNotifications = true }
+                // 백그라운드에서 수신해둔 미처리 COMPLETED 알림 소비 (알림 탭 없이 직접 진입한 경우)
+                await consumeDeliveredCompletedNotifications()
                 // 앱 직접 복귀 경로: COMPLETED 감지를 위해 1회 동기화
                 // pendingNotificationAction이 설정된 경우 딥링크 경로에서 이미 갱신 처리 -> 중복 스킵
                 if appState.pendingNotificationAction == nil {
@@ -448,6 +451,25 @@ struct MainTabBarView: View {
     private func handleMakeAlbumTabTap() {
         guard !isPresentingMakeAlbum else { return }
         presentMakeAlbumFlow()
+    }
+
+    // 백그라운드에서 수신했으나 탭되지 않은 COMPLETED 알림을 찾아 handleAlbumCompleted로 소비
+    // 처리된 알림은 알림 센터에서 제거하여 중복 처리 방지
+    private func consumeDeliveredCompletedNotifications() async {
+        let center = UNUserNotificationCenter.current()
+        let delivered = await center.deliveredNotifications()
+        var processedIdentifiers: [String] = []
+        for notification in delivered {
+            let userInfo = notification.request.content.userInfo
+            guard let payload = FCMPayload.decode(from: userInfo),
+                  payload.type == "COMPLETED",
+                  let albumId = payload.data?.albumId else { continue }
+            await mainPageViewModel.handleAlbumCompleted(albumId: albumId)
+            processedIdentifiers.append(notification.request.identifier)
+        }
+        if !processedIdentifiers.isEmpty {
+            center.removeDeliveredNotifications(withIdentifiers: processedIdentifiers)
+        }
     }
 
     // 완료 알림 albumId로 단일 앨범 조회 후 해당 상세페이지 이동

--- a/VibeTrip/Views/MainTabBarView.swift
+++ b/VibeTrip/Views/MainTabBarView.swift
@@ -124,10 +124,8 @@ struct MainTabBarView: View {
             AlbumDetailView(
                 displayModel: presentation.displayModel,
                 onBackTap: {
-                    // 뒤로가기 시 캐러셀을 해당 앨범 카드 위치로 이동
                     appState.pendingCarouselAlbumId = presentation.displayModel.albumId
                     presentedAlbumDetail = nil
-                    selectedTab = .home
                     isTabBarHidden = false
                 },
                 onEditSaved: { outcome in
@@ -153,10 +151,12 @@ struct MainTabBarView: View {
             // albumId 기준으로 view 재생성 강제 -> @State/@StateObject 확실히 초기화
             .id(presentation.displayModel.albumId)
             .onAppear {
-                // 해당 앨범 상세페이지 이동 후 탭 전환
+                // 마스크 뒤에서 홈 탭 전환 + 해당 앨범 캐러셀 위치 세팅
+                // -> 뒤로가기 시 알림 탭 노출 없이 홈의 해당 앨범으로 복귀 보장
                 DispatchQueue.main.async {
                     Task { await mainPageViewModel.refreshAlbumsWithoutClearing() }
-                    // 상세 애니메이션 이후에 마스크를 해제 -> 탭 전환 노출 방지
+                    appState.pendingCarouselAlbumId = presentation.displayModel.albumId
+                    selectedTab = .home
                     isResolvingAlbumDetail = false
                 }
             }


### PR DESCRIPTION
## 📄 작업 내용
앱 내 오류들 수정

## 🔗 관련 이슈
<!-- ex) Closes #12 -->
closes #89 

## ✅ 체크리스트
- [ ] 여행 기간 선택 캘린더 시트 제목 잘리는 문제 해결
- [ ] 앨범 생성 중 토스트 표시 후 해제 안되는 문제 해결
- [ ] 백그라운드에서 생성 완료 알림 수신 후 앱 직접 진입 시, 스켈레톤 미해제 문제 해결
- [ ] 알림 탭으로 상세페이지 진입 후 뒤로가기 시 탭 전환 노출 문제 해결
