### PR TITLE
feature: 생성 대기 화면 체류 중 생성 완료 감지 시 자동 이탈 구현(#91)

### DIFF
--- a/VibeTrip/Models/AppState.swift
+++ b/VibeTrip/Models/AppState.swift
@@ -18,8 +18,7 @@ enum NotificationNavigationAction: Equatable {
     case openMakeAlbum
 
     // 앨범 생성 중: MakeAlbumLoadingView
-    // TODO: 서버 연동 시, MakeAlbumViewModel 상태 보존 후 기존 로딩 화면 복귀 구현 
-    case openAlbumCreationLoading
+    case openAlbumCreationLoading(albumId: String?)
 
     // 앨범 생성 완료: AlbumDetailView
     case openAlbumDetail(albumId: String)

--- a/VibeTrip/Models/FCMPayloadModel.swift
+++ b/VibeTrip/Models/FCMPayloadModel.swift
@@ -74,7 +74,7 @@ extension FCMPayload {
     func toNavigationAction() -> NotificationNavigationAction? {
         switch type {
         case "CREATING":
-            return .openAlbumCreationLoading
+            return .openAlbumCreationLoading(albumId: data?.albumId.map { String($0) })
         case "COMPLETED":
             // albumId 누락 시 홈 탭으로 이동하는 fallback 처리
             guard let albumId = data?.albumId else { return .openHome }

--- a/VibeTrip/Models/NotificationModel.swift
+++ b/VibeTrip/Models/NotificationModel.swift
@@ -12,7 +12,7 @@ import Foundation
 // 알림 case
 enum NotificationType {
     // 앨범 생성 중
-    case generating
+    case generating(albumId: String?)
     // 앨범 생성 완료
     case completed(albumId: String) /// albumId: 이동할 앨범 식별자
     // 앨범 생성 실패

--- a/VibeTrip/Services/AlarmServiceProtocol.swift
+++ b/VibeTrip/Services/AlarmServiceProtocol.swift
@@ -42,7 +42,7 @@ extension AlarmResponse {
     private func toNotificationType() -> NotificationType? {
         switch alarmType {
         case "CREATING":
-            return .generating
+            return .generating(albumId: albumId.map { String($0) })
         case "COMPLETED":
             // COMPLETED는 반드시 albumId가 필요
             guard let albumId else { return nil }

--- a/VibeTrip/ViewModels/MainPageViewModel.swift
+++ b/VibeTrip/ViewModels/MainPageViewModel.swift
@@ -20,6 +20,7 @@ final class MainPageViewModel: ObservableObject {
     @Published private(set) var isLoading: Bool = false     // 네트워크 요청 중 여부
     @Published private(set) var errorMessage: String? = nil // 에러 발생 시 메시지
     @Published private(set) var didFinishInitialLoad: Bool = false // 최초 API 응답 완료 여부
+    @Published private(set) var lastCompletedAlbumId: Int? = nil  // 가장 최근 완료된 앨범 ID (FCM 및 폴링 공통)
 
     // 신고로 숨긴 앨범 ID 목록 (클라이언트 인메모리, API 연동 전 목 처리)
     private var hiddenAlbumIds: Set<Int> = []
@@ -258,6 +259,7 @@ final class MainPageViewModel: ObservableObject {
         readyAlbumIds.insert(albumId)
         pendingPollingIds.remove(albumId)
         pollingTasks[albumId] = nil
+        lastCompletedAlbumId = albumId
     }
 
     // 신고된 앨범을 로컬에서 숨김 처리

--- a/VibeTrip/ViewModels/NotificationViewModel.swift
+++ b/VibeTrip/ViewModels/NotificationViewModel.swift
@@ -143,8 +143,7 @@ final class NotificationViewModel: ObservableObject {
         return Set(stored)
     }
 
-    // 같은 albumId: 최신 항목 하나만 유지
-    // CREATING -> COMPLETED or FAILED
+    // 같은 albumId: 가장 최신 항목 하나만 유지
     private func deduplicated(_ responses: [AlarmResponse]) -> [AlarmResponse] {
         // albumId 없는 항목은 그대로 유지
         let noAlbumIdItems = responses.filter { $0.albumId == nil }
@@ -152,14 +151,43 @@ final class NotificationViewModel: ObservableObject {
         // albumId 있는 항목들을 그룹핑 후 각 그룹에서 하나만 선택
         let grouped = Dictionary(grouping: responses.filter { $0.albumId != nil }, by: { $0.albumId! })
         let deduped: [AlarmResponse] = grouped.values.compactMap { group in
-            // COMPLETED or FAILED 중 가장 최신(alarmId 높은) 우선
-            let resolved = group.filter { $0.alarmType == "COMPLETED" || $0.alarmType == "FAILED" }
-            if let latest = resolved.max(by: { $0.alarmId < $1.alarmId }) { return latest }
-            // CREATING만 있으면 그 중 최신
-            return group.max(by: { $0.alarmId < $1.alarmId })
+            group.max { lhs, rhs in
+                let lhsDate = parseAlarmDate(lhs.createdAt)
+                let rhsDate = parseAlarmDate(rhs.createdAt)
+                if lhsDate == rhsDate {
+                    return lhs.alarmId < rhs.alarmId
+                }
+                return lhsDate < rhsDate
+            }
         }
 
         return noAlbumIdItems + deduped
     }
+
+    private func parseAlarmDate(_ string: String) -> Date {
+        if let date = Self.isoFormatterWithFraction.date(from: string) { return date }
+        if let date = Self.isoFormatterWithoutFraction.date(from: string) { return date }
+        if let date = Self.plainDateTimeFormatter.date(from: string) { return date }
+        return Date.distantPast
+    }
+
+    private static let isoFormatterWithFraction: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let isoFormatterWithoutFraction: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    private static let plainDateTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }()
 
 }

--- a/VibeTrip/Views/MainTabBarView.swift
+++ b/VibeTrip/Views/MainTabBarView.swift
@@ -67,10 +67,11 @@ struct MainTabBarView: View {
 
     // 앨범 생성 로딩 관련 상태
     @State private var isAlbumCreating = false                                                  // 요청 진행 중 여부
+    @State private var creatingAlbumId: Int? = nil                                             // 생성 요청한 앨범 ID (완료 감지용)
     @State private var albumLoadingError: MakeAlbumViewModel.AlbumCreationLoadingError? = nil  // 에러 팝업 종류
     @State private var albumRetryAction: (() -> Void)? = nil                                  // 네트워크 오류 재시도 클로저
     @State private var hiddenLoadingToastMessage: String? = nil
-    @State private var hiddenLoadingToastShowsIcon = false
+    @State private var hiddenLoadingToastIconName: String? = nil
     // 완료 알림 상세 진입 전 데이터 조회 중 화면 전환 가리는 상태
     @State private var isResolvingAlbumDetail = false
     @State private var presentedAlbumDetail: PendingAlbumDetailPresentation? = nil
@@ -269,6 +270,14 @@ struct MainTabBarView: View {
             appState.needsSilentAlbumRefresh = false
             Task { await mainPageViewModel.refreshAlbumsWithoutClearing() }
         }
+        // 앨범 생성 완료 감지 (FCM·폴링 공통): 생성 대기화면 자동 이탈
+        .onChange(of: mainPageViewModel.lastCompletedAlbumId) { _, completedId in
+            guard let completedId,
+                  let creatingId = creatingAlbumId,
+                  completedId == creatingId,
+                  isPresentingLoadingView else { return }
+            autoHideLoadingViewOnCompletion()
+        }
     }
 
     // ZStack 콘텐츠를 body에서 분리
@@ -313,9 +322,10 @@ struct MainTabBarView: View {
                         }
                     },
                     onCreationSuccess: { albumId in
-                        // 생성 성공: 화면 숨기기 버튼 활성화
+                        // 생성 성공: 화면 숨기기 버튼 활성화 + 완료 감지용 albumId 저장
                         isAlbumCreating = false
                         albumLoadingError = nil
+                        creatingAlbumId = albumId
                     },
                     onNetworkError: { retryAction in
                         // 네트워크 오류: 재시도 클로저 보관 후 팝업 표시
@@ -343,7 +353,7 @@ struct MainTabBarView: View {
                         withAnimation(.easeInOut(duration: 0.24)) {
                             isPresentingLoadingView = false
                             isPresentingMakeAlbum = false
-                            hiddenLoadingToastShowsIcon = true
+                            hiddenLoadingToastIconName = "exclamationmark.circle"
                             hiddenLoadingToastMessage = "앨범을 제작하고 있어요. 잠시만 기다려 주세요!"
                         }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
@@ -388,7 +398,7 @@ struct MainTabBarView: View {
                 VStack {
                     Spacer()
                     AppToastView(message: hiddenLoadingToastMessage,
-                                 systemImageName: hiddenLoadingToastShowsIcon ? "exclamationmark.circle" : nil)
+                                 systemImageName: hiddenLoadingToastIconName)
                         .padding(.bottom, Constants.hideLoadingToastBottomPadding)
                         .transition(.move(edge: .bottom).combined(with: .opacity))
                         .onAppear {
@@ -426,8 +436,29 @@ struct MainTabBarView: View {
         withAnimation(.easeInOut(duration: 0.24)) {
             isPresentingLoadingView = false
             isPresentingMakeAlbum = false
-            hiddenLoadingToastShowsIcon = true
+            hiddenLoadingToastIconName = "exclamationmark.circle"
             hiddenLoadingToastMessage = "앨범 만들기를 취소했어요."
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
+            withAnimation(.easeInOut(duration: 0.22)) {
+                isTabBarHidden = false
+            }
+        }
+    }
+
+    // 생성 완료 감지 시 자동으로 로딩 화면 숨기기
+    private func autoHideLoadingViewOnCompletion() {
+        if let albumId = creatingAlbumId {
+            appState.pendingCarouselAlbumId = albumId
+        }
+        creatingAlbumId = nil
+        selectedTab = .home
+        DispatchQueue.main.async { appState.needsAlbumRefresh = true }
+        withAnimation(.easeInOut(duration: 0.24)) {
+            isPresentingLoadingView = false
+            isPresentingMakeAlbum = false
+            hiddenLoadingToastIconName = "checkmark.circle"
+            hiddenLoadingToastMessage = "앨범 생성이 완료됐어요!"
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
             withAnimation(.easeInOut(duration: 0.22)) {
@@ -483,7 +514,7 @@ struct MainTabBarView: View {
                 selectedTab = .home
                 isTabBarHidden = false
                 isResolvingAlbumDetail = false
-                hiddenLoadingToastShowsIcon = true
+                hiddenLoadingToastIconName = "exclamationmark.circle"
                 hiddenLoadingToastMessage = Constants.deletedAlbumToastMessage
             }
             return

--- a/VibeTrip/Views/MainTabBarView.swift
+++ b/VibeTrip/Views/MainTabBarView.swift
@@ -451,12 +451,9 @@ struct MainTabBarView: View {
 
     // 생성 완료 감지 시 자동으로 로딩 화면 숨기기
     private func autoHideLoadingViewOnCompletion() {
-        if let albumId = creatingAlbumId {
-            appState.pendingCarouselAlbumId = albumId
-        }
+        let completedAlbumId = creatingAlbumId
         creatingAlbumId = nil
         selectedTab = .home
-        DispatchQueue.main.async { appState.needsAlbumRefresh = true }
         withAnimation(.easeInOut(duration: 0.24)) {
             isPresentingLoadingView = false
             isPresentingMakeAlbum = false
@@ -466,6 +463,13 @@ struct MainTabBarView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
             withAnimation(.easeInOut(duration: 0.22)) {
                 isTabBarHidden = false
+            }
+        }
+        // 앨범 갱신 완료 후 위치 세팅 -> 갱신 전 소비되어 위치 이동이 무시되는 문제 방지
+        Task {
+            await mainPageViewModel.refreshAlbumsWithoutClearing()
+            if let albumId = completedAlbumId {
+                appState.pendingCarouselAlbumId = albumId
             }
         }
     }

--- a/VibeTrip/Views/MainTabBarView.swift
+++ b/VibeTrip/Views/MainTabBarView.swift
@@ -203,9 +203,12 @@ struct MainTabBarView: View {
                         isPresentingMakeAlbum = true
                     }
                 }
-            case .openAlbumCreationLoading:
+            case .openAlbumCreationLoading(let albumId):
                 // 생성 중: MakeAlbumLoadingView
                 // TODO: 서버 연동 시, 기존 생성 중인 ViewModel 상태 복원
+                if let albumId, let id = Int(albumId) {
+                    creatingAlbumId = id
+                }
                 withAnimation(.easeInOut(duration: 0.18)) {
                     isTabBarHidden = true
                 }

--- a/VibeTrip/Views/NotificationView.swift
+++ b/VibeTrip/Views/NotificationView.swift
@@ -181,11 +181,11 @@ struct NotificationView: View {
         viewModel.markAsRead(id: item.id)
 
         switch item.type {
-        case .generating:
+        case .generating(let albumId):
             // TODO: 서버 연동 시, 해당 앨범의 로딩 페이지 이동
             // 현재는 새 MakeAlbumView를 열며, 이전 로딩 상태는 복원되지 않음
             // MakeAlbumViewModel: AppState or 상위 레벨에서 보존 필요
-            appState.pendingNotificationAction = .openAlbumCreationLoading
+            appState.pendingNotificationAction = .openAlbumCreationLoading(albumId: albumId)
 
         case .completed(let albumId):
             appState.pendingNotificationAction = .openAlbumDetail(albumId: albumId)
@@ -301,7 +301,7 @@ private struct NotificationRow: View {
     let vm = NotificationViewModel(previewNotifications: [
         NotificationItem(
             id: "1",
-            type: .generating,
+            type: .generating(albumId: nil),
             title: "앨범을 생성하는 중입니다.",
             body: "나만의 음악이 곧 탄생합니다. 완료되면 바로 알려드릴게요.",
             createdAt: Date(timeIntervalSinceNow: -120),

--- a/VibeTripTests/AlbumLogViewModelTests.swift
+++ b/VibeTripTests/AlbumLogViewModelTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import UIKit
 @testable import VibeTrip
 
 // MARK: - StubAlbumLogService
@@ -122,9 +123,17 @@ final class AlbumLogViewModelTests: XCTestCase {
 
     // MARK: - addPhotos
 
+    private func makeTestImage(size: CGSize = CGSize(width: 10, height: 10)) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { context in
+            UIColor.red.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
+    }
+
     // 5장 이하 추가 -> selectedPhotos에 정상 반영
     func test_addPhotos_withinLimit_addsPhotos() {
-        let images = (0..<3).map { _ in UIImage() }
+        let images = (0..<3).map { _ in makeTestImage() }
 
         sut.addPhotos(images)
 
@@ -133,7 +142,7 @@ final class AlbumLogViewModelTests: XCTestCase {
 
     // 5장 초과 추가 -> 한도 초과 토스트 메시지 설정
     func test_addPhotos_exceedLimit_showsToast() {
-        let images = (0..<6).map { _ in UIImage() }
+        let images = (0..<6).map { _ in makeTestImage() }
 
         sut.addPhotos(images)
 

--- a/VibeTripTests/MainPageViewModelTests.swift
+++ b/VibeTripTests/MainPageViewModelTests.swift
@@ -135,8 +135,8 @@ final class MainPageViewModelTests: XCTestCase {
         XCTAssertNil(sut.errorMessage)
     }
 
-    // 앨범 생성 완료 조건: musicUrl
-    func test_loadAlbums_titleExists_butMusicNotReady_isNotReady() async {
+    // title이 있고 재생성 대기 중이 아니면 ready 처리
+    func test_loadAlbums_titleExists_marksAlbumReady() async {
         let cards = makeAlbumCards(ids: [1])
         let stub = StubAlbumService(results: [
             .success(AlbumListPayload(content: cards, totalCount: 1, hasNext: false))
@@ -145,7 +145,7 @@ final class MainPageViewModelTests: XCTestCase {
 
         await sut.loadAlbums()
 
-        XCTAssertFalse(sut.isReady(for: 1))
+        XCTAssertTrue(sut.isReady(for: 1))
     }
 
     // 에러 응답 -> errorMessage 설정됨, albums 비어있음

--- a/VibeTripTests/NotificationFlowTests.swift
+++ b/VibeTripTests/NotificationFlowTests.swift
@@ -141,6 +141,74 @@ final class NotificationFlowTests: XCTestCase {
         }
     }
 
+    // 같은 albumId에서 예전 COMPLETED 후 새 CREATING이 오면 최신 CREATING 표시
+    func test_loadNotifications_sameAlbumOldCompletedAndNewCreating_keepsLatestCreatingOne() async {
+        let stub = StubAlarmServiceForNotificationFlow()
+        stub.fetchResult = .success([
+            AlarmResponse(
+                alarmId: 30,
+                title: "생성 완료",
+                description: "completed",
+                alarmType: "COMPLETED",
+                createdAt: "2026-04-09T12:00:00",
+                albumId: 400
+            ),
+            AlarmResponse(
+                alarmId: 31,
+                title: "생성 중",
+                description: "creating",
+                alarmType: "CREATING",
+                createdAt: "2026-04-09T12:05:00",
+                albumId: 400
+            )
+        ])
+        let sut = NotificationViewModel(alarmService: stub)
+
+        await sut.loadNotifications()
+
+        XCTAssertEqual(sut.notifications.count, 1)
+        XCTAssertEqual(sut.notifications.first?.id, "31")
+        if case .generating(let albumId) = sut.notifications.first?.type {
+            XCTAssertEqual(albumId, "400")
+        } else {
+            XCTFail("기대 타입(.generating)과 다릅니다.")
+        }
+    }
+
+    // 같은 albumId에서 CREATING 후 FAILED가 오면 최신 FAILED 표시
+    func test_loadNotifications_sameAlbumCreatingAndFailed_keepsLatestFailedOne() async {
+        let stub = StubAlarmServiceForNotificationFlow()
+        stub.fetchResult = .success([
+            AlarmResponse(
+                alarmId: 40,
+                title: "생성 중",
+                description: "creating",
+                alarmType: "CREATING",
+                createdAt: "2026-04-09T13:00:00",
+                albumId: 500
+            ),
+            AlarmResponse(
+                alarmId: 41,
+                title: "생성 실패",
+                description: "failed",
+                alarmType: "FAILED",
+                createdAt: "2026-04-09T13:02:00",
+                albumId: 500
+            )
+        ])
+        let sut = NotificationViewModel(alarmService: stub)
+
+        await sut.loadNotifications()
+
+        XCTAssertEqual(sut.notifications.count, 1)
+        XCTAssertEqual(sut.notifications.first?.id, "41")
+        if case .failed = sut.notifications.first?.type {
+            // expected
+        } else {
+            XCTFail("기대 타입(.failed)과 다릅니다.")
+        }
+    }
+
     // 알림 목록은 createdAt 기준 최신순(내림차순)으로 정렬되
     func test_loadNotifications_sortsByLatestCreatedAtFirst() async {
         let stub = StubAlarmServiceForNotificationFlow()

--- a/VibeTripTests/NotificationFlowTests.swift
+++ b/VibeTripTests/NotificationFlowTests.swift
@@ -34,7 +34,7 @@ final class NotificationFlowTests: XCTestCase {
             error: nil
         )
 
-        XCTAssertEqual(payload.toNavigationAction(), .openAlbumCreationLoading)
+        XCTAssertEqual(payload.toNavigationAction(), .openAlbumCreationLoading(albumId: "11"))
     }
 
     // COMPLETED 푸시 payload는 해당 albumId 상세 화면 액션으로 매핑


### PR DESCRIPTION
## 📄 작업 내용
생성 요청을 보낸 후, 생성 대기화면에서 체류하고 있다가 해당 앨범 생성 완료 시 자동 화면 숨기기 처리

## 🔗 관련 이슈
<!-- ex) Closes #12 -->
Closes #91 

## ✅ 체크리스트
- [ ] 푸시 알림으로 생성 대기 화면 진입 후 생성 완료 시, 메인페이지로 자동 이동
- [ ] 알림 항목에서 탭으로 생성 대기 화면 진입 후 생성 완료 시, 메인페이지로 자동 이동
