### PR TITLE
fix: 백그라운드에서 복귀 시, 새알림에 대한 레드닷, 배경색이 표시 안되는 문제 수정

### DIFF
--- a/VibeTrip/Models/AppState.swift
+++ b/VibeTrip/Models/AppState.swift
@@ -40,10 +40,6 @@ struct AppToastPayload: Equatable {
     // nil: 확인 중, true: 로그인, false: 로그아웃
     @Published var isLoggedIn: Bool? = nil
 
-    // 탭바 레드 닷 표시 여부
-    // true: 새 알림 존재, false: 존재X or 탭 진입 후
-    @Published var hasUnreadNotifications: Bool = false
-
     // 알림 탭 시 이동할 화면
     // NotificationView(세팅) -> MainTabBarView: onChange에서 화면 전환 처리 및 nil 초기화
     @Published var pendingNotificationAction: NotificationNavigationAction? = nil

--- a/VibeTrip/VibeTripApp.swift
+++ b/VibeTrip/VibeTripApp.swift
@@ -17,7 +17,30 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     private enum Constants {
         static let notificationKey = "isNotificationEnabled"
     }
-    weak var appState: AppState?
+
+    // appState 설정 전에 수신된 콜백 신호를 버퍼링하기 위한 프로퍼티
+    private struct PendingReceivePayload {
+        let navigationAction: NotificationNavigationAction?
+    }
+    private var pendingNeedsActiveCheck = false
+    private var pendingReceivePayload: PendingReceivePayload? = nil
+
+    weak var appState: AppState? {
+        didSet {
+            guard let appState else { return }
+            if pendingNeedsActiveCheck {
+                pendingNeedsActiveCheck = false
+                Task { @MainActor in appState.needsActiveCheck = true }
+            }
+            if let pending = pendingReceivePayload {
+                pendingReceivePayload = nil
+                Task { @MainActor in
+                    appState.needsNotificationRefresh = true
+                    appState.pendingNotificationAction = pending.navigationAction
+                }
+            }
+        }
+    }
 
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
@@ -67,8 +90,10 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 
     // 앱 포그라운드 전환 시: 미읽음/FAILED 알림 여부 확인 요청
     func applicationDidBecomeActive(_ application: UIApplication) {
-        Task { @MainActor in
-            appState?.needsActiveCheck = true
+        if let appState {
+            Task { @MainActor in appState.needsActiveCheck = true }
+        } else {
+            pendingNeedsActiveCheck = true
         }
     }
 
@@ -81,7 +106,6 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         let userInfo = notification.request.content.userInfo
         let payload = FCMPayload.decode(from: userInfo)
         Task { @MainActor in
-            appState?.hasUnreadNotifications = true
             appState?.needsNotificationRefresh = true
             if payload?.type == "FAILED" {
                 appState?.needsSilentAlbumRefresh = true
@@ -99,10 +123,13 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
         let userInfo = response.notification.request.content.userInfo
         let navigationAction = FCMPayload.decode(from: userInfo)?.toNavigationAction()
-        Task { @MainActor in
-            appState?.hasUnreadNotifications = true
-            appState?.needsNotificationRefresh = true
-            appState?.pendingNotificationAction = navigationAction
+        if let appState {
+            Task { @MainActor in
+                appState.needsNotificationRefresh = true
+                appState.pendingNotificationAction = navigationAction
+            }
+        } else {
+            pendingReceivePayload = PendingReceivePayload(navigationAction: navigationAction)
         }
         completionHandler()
     }

--- a/VibeTrip/ViewModels/NotificationViewModel.swift
+++ b/VibeTrip/ViewModels/NotificationViewModel.swift
@@ -17,6 +17,7 @@ final class NotificationViewModel: ObservableObject {
 
     // 화면에 표시할 알림 목록
     @Published private(set) var notifications: [NotificationItem] = [] 
+    @Published private(set) var showsUnreadBadge = false
 
     // MARK: - Dependencies
 
@@ -78,6 +79,43 @@ final class NotificationViewModel: ObservableObject {
         await loadNotifications()
     }
 
+    // 앱 내부에서 새 알림 이벤트를 받았을 때 레드닷/목록 상태를 함께 갱신
+    func handleIncomingNotification(isViewingNotificationTab: Bool) async {
+        if isViewingNotificationTab {
+            showsUnreadBadge = false
+            await loadNotifications()
+        } else {
+            showsUnreadBadge = true
+        }
+    }
+
+    // 앱 복귀 시 현재 위치에 맞춰 레드닷/목록 상태를 한 곳에서 처리
+    func handleAppBecameActive(
+        isViewingNotificationTab: Bool,
+        hasDeliveredNotifications: Bool
+    ) async {
+        if isViewingNotificationTab {
+            showsUnreadBadge = false
+            await loadNotifications()
+            if hasDeliveredNotifications {
+                try? await Task.sleep(nanoseconds: 1_500_000_000)
+                await loadNotifications()
+            }
+            return
+        }
+
+        if hasDeliveredNotifications {
+            showsUnreadBadge = true
+        }
+
+        let result = await checkUnread()
+        showsUnreadBadge = hasDeliveredNotifications || result.hasUnread
+    }
+
+    func clearUnreadBadge() {
+        showsUnreadBadge = false
+    }
+
     // 앱 포그라운드 진입 시 미읽음/FAILED 알림 여부만 확인 (notifications 배열 미변경)
     func checkUnread() async -> (hasUnread: Bool, hasFailed: Bool) {
         guard let responses = try? await alarmService.fetchAlarms() else { return (false, false) }
@@ -96,6 +134,9 @@ final class NotificationViewModel: ObservableObject {
         var stored = loadReadIds()
         stored.insert(id)
         saveReadIds(stored)
+        if notifications.allSatisfy({ $0.isRead }) {
+            showsUnreadBadge = false
+        }
     }
 
     // 알림 삭제 + UserDefaults에서 읽음 ID 제거
@@ -122,6 +163,7 @@ final class NotificationViewModel: ObservableObject {
         var stored = loadReadIds()
         stored.formUnion(notifications.map { $0.id })
         saveReadIds(stored)
+        showsUnreadBadge = false
     }
 
     // MARK: - Private Methods

--- a/VibeTrip/ViewModels/NotificationViewModel.swift
+++ b/VibeTrip/ViewModels/NotificationViewModel.swift
@@ -80,12 +80,14 @@ final class NotificationViewModel: ObservableObject {
     }
 
     // 앱 내부에서 새 알림 이벤트를 받았을 때 레드닷/목록 상태를 함께 갱신
+    // 알림탭 밖: 최신 목록을 로드해 실제 미읽음 항목이 있을 때만 배지 ON -> 이미 읽은 알림을 시스템 알림센터에서 탭한 경우 배지가 잘못 켜지는 문제 방지
     func handleIncomingNotification(isViewingNotificationTab: Bool) async {
         if isViewingNotificationTab {
             showsUnreadBadge = false
             await loadNotifications()
         } else {
-            showsUnreadBadge = true
+            await loadNotifications()
+            showsUnreadBadge = notifications.contains { !$0.isRead }
         }
     }
 
@@ -104,12 +106,14 @@ final class NotificationViewModel: ObservableObject {
             return
         }
 
+        // API 응답 지연 대비 표시 -> API 결과로 최종 덮어씀
         if hasDeliveredNotifications {
             showsUnreadBadge = true
         }
 
+        // readAlarmIds 기반 실제 미읽음 여부만 최종 반영 -> 알림센터에 남은 이미 읽은 알림 때문에 배지가 고착되는 문제 방지
         let result = await checkUnread()
-        showsUnreadBadge = hasDeliveredNotifications || result.hasUnread
+        showsUnreadBadge = result.hasUnread
     }
 
     func clearUnreadBadge() {

--- a/VibeTrip/Views/MainTabBarView.swift
+++ b/VibeTrip/Views/MainTabBarView.swift
@@ -94,21 +94,24 @@ struct MainTabBarView: View {
 
     var body: some View {
         mainStackWithHandlers
+        .onAppear {
+            if appState.needsNotificationRefresh {
+                appState.needsNotificationRefresh = false
+                Task { await processNotificationRefresh() }
+            }
+            if let action = appState.pendingNotificationAction {
+                appState.pendingNotificationAction = nil
+                handlePendingNotificationAction(action)
+            }
+            guard appState.needsActiveCheck else { return }
+            appState.needsActiveCheck = false
+            Task { await processActiveCheck() }
+        }
         // 앱 포그라운드 전환 시: 미읽음/FAILED 알림 여부 확인 후 red dot 및 앨범 목록 갱신
         .onChange(of: appState.needsActiveCheck) { _, needsCheck in
             guard needsCheck else { return }
             appState.needsActiveCheck = false
-            Task {
-                let result = await notificationViewModel.checkUnread()
-                if result.hasUnread { appState.hasUnreadNotifications = true }
-                // 백그라운드에서 수신해둔 미처리 COMPLETED 알림 소비 (알림 탭 없이 직접 진입한 경우)
-                await consumeDeliveredCompletedNotifications()
-                // 앱 직접 복귀 경로: COMPLETED 감지를 위해 1회 동기화
-                // pendingNotificationAction이 설정된 경우 딥링크 경로에서 이미 갱신 처리 -> 중복 스킵
-                if appState.pendingNotificationAction == nil {
-                    await mainPageViewModel.refreshAlbumsWithoutClearing()
-                }
-            }
+            Task { await processActiveCheck() }
         }
         // 포그라운드 FCM COMPLETED 수신 시: 해당 앨범 폴링 취소 후 1회 조회로 완료 처리
         .onChange(of: appState.fcmCompletedAlbumId) { _, albumId in
@@ -172,84 +175,30 @@ struct MainTabBarView: View {
         .animation(.easeInOut(duration: 0.24), value: isPresentingMakeAlbum)
         .animation(.easeInOut(duration: 0.22), value: isTabBarHidden)
         .animation(.easeInOut(duration: 0.2), value: hiddenLoadingToastMessage)
-        // 알림 탭 탈출 시 전체 읽음 처리
         .onChange(of: selectedTab) { oldTab, newTab in
+            if newTab == .notification {
+                notificationViewModel.clearUnreadBadge()
+            }
             guard oldTab == .notification, newTab != .notification else { return }
             notificationViewModel.markAllAsRead()
-            appState.hasUnreadNotifications = false
         }
         .onChange(of: isPresentingMakeAlbum) { _, isPresenting in
             guard isPresenting, selectedTab == .notification else { return }
             notificationViewModel.markAllAsRead()
-            appState.hasUnreadNotifications = false
         }
         .onChange(of: isPresentingLoadingView) { _, isPresenting in
             guard isPresenting, selectedTab == .notification else { return }
-            notificationViewModel.markAllAsRead()
-            appState.hasUnreadNotifications = false
+            notificationViewModel.clearUnreadBadge()
         }
-        // 알림 탭 시, 화면 이동
+        .onChange(of: appState.needsNotificationRefresh) { _, needsRefresh in
+            guard needsRefresh else { return }
+            appState.needsNotificationRefresh = false
+            Task { await processNotificationRefresh() }
+        }
         .onChange(of: appState.pendingNotificationAction) { _, action in
             guard let action else { return }
-            switch action {
-            case .openMakeAlbum:
-                // 생성 실패: MakeAlbumView 진입 전 탭 상태 무관하게 앨범 목록 즉시 갱신
-                Task { await mainPageViewModel.refreshAlbumsWithoutClearing() }
-                withAnimation(.easeInOut(duration: 0.18)) {
-                    isTabBarHidden = true
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
-                    withAnimation(.easeInOut(duration: 0.24)) {
-                        isPresentingMakeAlbum = true
-                    }
-                }
-            case .openAlbumCreationLoading(let albumId):
-                // 생성 중: MakeAlbumLoadingView
-                // TODO: 서버 연동 시, 기존 생성 중인 ViewModel 상태 복원
-                if let albumId, let id = Int(albumId) {
-                    creatingAlbumId = id
-                }
-                withAnimation(.easeInOut(duration: 0.18)) {
-                    isTabBarHidden = true
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
-                    withAnimation(.easeInOut(duration: 0.24)) {
-                        isPresentingLoadingView = true
-                    }
-                }
-            case .openAlbumDetail(let albumId):
-                // 백그라운드 푸시 탭 진입 경로에서도 완료 처리 동기화
-                if let numericAlbumId = Int(albumId) {
-                    Task { await mainPageViewModel.handleAlbumCompleted(albumId: numericAlbumId) }
-                }
-
-                // 어느 경로로 커버가 열려 있는지 각각 확인
-                let hadPresentedDetail = presentedAlbumDetail != nil         // MainTabBarView 경유
-                let hadSelectedAlbum = !hadPresentedDetail && appState.isAlbumDetailPresented  // MainPageView 경유
-
-                withAnimation(.easeInOut(duration: 0.24)) {
-                    isPresentingLoadingView = false
-                    isPresentingMakeAlbum = false
-                    isTabBarHidden = true
-                }
-
-                if hadPresentedDetail {
-                    // MainTabBarView 자체 커버가 열려 있음 -> fullScreenCover onDismiss에서 dismiss 완료 시점에 새 커버 진입
-                    ownCoverPendingAlbumId = albumId
-                    presentedAlbumDetail = nil
-                } else if hadSelectedAlbum {
-                    // MainPageView 커버가 열려 있음 -> needsDismissAlbumDetail로 dismiss 트리거, onDismiss에서 AppState 시그널 발송
-                    appState.pendingDeeplinkAlbumId = albumId
-                    appState.needsDismissAlbumDetail = true
-                } else {
-                    // 열린 커버 없음 -> 즉시 진입
-                    Task { await presentAlbumDetailOverlay(albumId: albumId) }
-                }
-            case .openHome:
-                // albumId 누락 등 상세 진입 불가 시: 홈 탭으로 이동
-                selectedTab = .home
-            }
             appState.pendingNotificationAction = nil
+            handlePendingNotificationAction(action)
         }
         // presentedAlbumDetail 변화 시 AppState 동기화: 딥링크 수신 시 기존 커버 유무 판단에 사용
         .onChange(of: presentedAlbumDetail?.id) { _, detailId in
@@ -390,6 +339,7 @@ struct MainTabBarView: View {
                         selectedTab: $selectedTab,
                         isTabBarHidden: $isTabBarHidden,
                         isPresentingMakeAlbum: $isPresentingMakeAlbum,
+                        showsNotificationBadge: notificationViewModel.showsUnreadBadge,
                         // 탭바 내부에서 직접 진입하지 않고, 상위에서 팝업/진입 가드를 판단
                         onMakeAlbumTap: handleMakeAlbumTabTap
                     )
@@ -491,6 +441,81 @@ struct MainTabBarView: View {
         presentMakeAlbumFlow()
     }
 
+    private func processNotificationRefresh() async {
+        await notificationViewModel.handleIncomingNotification(
+            isViewingNotificationTab: selectedTab == .notification
+        )
+    }
+
+    // 앱 포그라운드 복귀 시 알림 동기화 처리
+    private func processActiveCheck() async {
+        let delivered = await UNUserNotificationCenter.current().deliveredNotifications()
+        await notificationViewModel.handleAppBecameActive(
+            isViewingNotificationTab: selectedTab == .notification,
+            hasDeliveredNotifications: !delivered.isEmpty
+        )
+
+        // 백그라운드에서 수신해둔 미처리 COMPLETED 알림 소비 (알림 탭 없이 직접 진입한 경우)
+        await consumeDeliveredCompletedNotifications()
+        // 앱 직접 복귀 경로: COMPLETED 감지를 위해 1회 동기화
+        // pendingNotificationAction이 설정된 경우 딥링크 경로에서 이미 갱신 처리 -> 중복 스킵
+        if appState.pendingNotificationAction == nil {
+            await mainPageViewModel.refreshAlbumsWithoutClearing()
+        }
+    }
+
+    private func handlePendingNotificationAction(_ action: NotificationNavigationAction) {
+        switch action {
+        case .openMakeAlbum:
+            Task { await mainPageViewModel.refreshAlbumsWithoutClearing() }
+            withAnimation(.easeInOut(duration: 0.18)) {
+                isTabBarHidden = true
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+                withAnimation(.easeInOut(duration: 0.24)) {
+                    isPresentingMakeAlbum = true
+                }
+            }
+        case .openAlbumCreationLoading(let albumId):
+            if let albumId, let id = Int(albumId) {
+                creatingAlbumId = id
+            }
+            withAnimation(.easeInOut(duration: 0.18)) {
+                isTabBarHidden = true
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+                withAnimation(.easeInOut(duration: 0.24)) {
+                    isPresentingLoadingView = true
+                }
+            }
+        case .openAlbumDetail(let albumId):
+            if let numericAlbumId = Int(albumId) {
+                Task { await mainPageViewModel.handleAlbumCompleted(albumId: numericAlbumId) }
+            }
+
+            let hadPresentedDetail = presentedAlbumDetail != nil
+            let hadSelectedAlbum = !hadPresentedDetail && appState.isAlbumDetailPresented
+
+            withAnimation(.easeInOut(duration: 0.24)) {
+                isPresentingLoadingView = false
+                isPresentingMakeAlbum = false
+                isTabBarHidden = true
+            }
+
+            if hadPresentedDetail {
+                ownCoverPendingAlbumId = albumId
+                presentedAlbumDetail = nil
+            } else if hadSelectedAlbum {
+                appState.pendingDeeplinkAlbumId = albumId
+                appState.needsDismissAlbumDetail = true
+            } else {
+                Task { await presentAlbumDetailOverlay(albumId: albumId) }
+            }
+        case .openHome:
+            selectedTab = .home
+        }
+    }
+
     // 백그라운드에서 수신했으나 탭되지 않은 COMPLETED 알림을 찾아 handleAlbumCompleted로 소비
     // 처리된 알림은 알림 센터에서 제거하여 중복 처리 방지
     private func consumeDeliveredCompletedNotifications() async {
@@ -566,10 +591,9 @@ struct LiquidGlassTabBar: View {
     @Binding var selectedTab: AppTab
     @Binding var isTabBarHidden: Bool
     @Binding var isPresentingMakeAlbum: Bool
+    let showsNotificationBadge: Bool
     // 앨범 만들기 진입 전 팝업/분기 처리
     let onMakeAlbumTap: () -> Void
-
-    @EnvironmentObject private var appState: AppState
 
     private enum Layout {
         static let iconSize: CGFloat      = 25   // 탭 아이콘 크기
@@ -641,7 +665,7 @@ struct LiquidGlassTabBar: View {
                 .scaledToFit()
                 .frame(width: Layout.iconSize, height: Layout.iconSize)
                 .overlay(alignment: .topTrailing) {
-                    if tab == .notification && appState.hasUnreadNotifications {
+                    if tab == .notification && showsNotificationBadge {
                         Circle()
                             .fill(Color.red)
                             .frame(width: 8, height: 8)

--- a/VibeTrip/Views/NotificationView.swift
+++ b/VibeTrip/Views/NotificationView.swift
@@ -14,7 +14,7 @@ struct NotificationView: View {
     // MARK: - ViewModel
 
     @StateObject private var viewModel: NotificationViewModel
-    // 탭바 레드 닷 제거 및 알림 탭 네비게이션
+    // 알림 탭 네비게이션
     @EnvironmentObject private var appState: AppState
 
     init(viewModel: NotificationViewModel = NotificationViewModel()) {
@@ -58,19 +58,7 @@ struct NotificationView: View {
             await viewModel.loadNotifications()
         }
         .onAppear {
-            // 탭 진입 시 레드 닷 제거
-            appState.hasUnreadNotifications = false
-            // 탭 진입 시 고착된 갱신 신호 초기화: 이후 추가 푸시 수신 시 onChange 정상 발동 보장
-            appState.needsNotificationRefresh = false
-        }
-        .onChange(of: appState.needsNotificationRefresh) { _, needsRefresh in
-            guard needsRefresh else { return }
-            appState.needsNotificationRefresh = false
-            Task {
-                await viewModel.loadNotifications()
-                // 알림 탭에 있는 상태에서는 레드닷이 다시 켜지지 않도록 유지
-                appState.hasUnreadNotifications = false
-            }
+            viewModel.clearUnreadBadge()
         }
     }
 

--- a/VibeTripTests/NotificationViewModelTests.swift
+++ b/VibeTripTests/NotificationViewModelTests.swift
@@ -124,6 +124,50 @@ final class NotificationViewModelTests: XCTestCase {
         XCTAssertEqual(sut.notifications.map(\.id), beforeIds)
     }
 
+    func test_handleIncomingNotification_outsideNotificationTab_turnsBadgeOnWithoutReload() async {
+        XCTAssertFalse(sut.showsUnreadBadge)
+
+        await sut.handleIncomingNotification(isViewingNotificationTab: false)
+
+        XCTAssertTrue(sut.showsUnreadBadge)
+        XCTAssertTrue(sut.notifications.isEmpty)
+    }
+
+    func test_handleIncomingNotification_insideNotificationTab_reloadsListAndKeepsBadgeOff() async {
+        stub.fetchResult = .success([
+            makeAlarmResponse(alarmId: 7, alarmType: "FAILED", albumId: nil)
+        ])
+
+        await sut.handleIncomingNotification(isViewingNotificationTab: true)
+
+        XCTAssertFalse(sut.showsUnreadBadge)
+        XCTAssertEqual(sut.notifications.map(\.id), ["7"])
+        XCTAssertFalse(sut.notifications.first?.isRead ?? true)
+    }
+
+    func test_handleAppBecameActive_withDeliveredNotification_keepsBadgeOnEvenBeforeAPISync() async {
+        stub.fetchResult = .success([])
+
+        await sut.handleAppBecameActive(
+            isViewingNotificationTab: false,
+            hasDeliveredNotifications: true
+        )
+
+        XCTAssertTrue(sut.showsUnreadBadge)
+    }
+
+    func test_handleAppBecameActive_withoutDeliveredOrUnread_clearsBadge() async {
+        await sut.handleIncomingNotification(isViewingNotificationTab: false)
+
+        stub.fetchResult = .success([])
+        await sut.handleAppBecameActive(
+            isViewingNotificationTab: false,
+            hasDeliveredNotifications: false
+        )
+
+        XCTAssertFalse(sut.showsUnreadBadge)
+    }
+
     // MARK: - UserDefaults 읽음 상태 영구 저장
 
     // markAsRead 후 앱 재시작(새 ViewModel) 시 해당 알림 읽음 상태 복원

--- a/VibeTripTests/NotificationViewModelTests.swift
+++ b/VibeTripTests/NotificationViewModelTests.swift
@@ -124,13 +124,28 @@ final class NotificationViewModelTests: XCTestCase {
         XCTAssertEqual(sut.notifications.map(\.id), beforeIds)
     }
 
-    func test_handleIncomingNotification_outsideNotificationTab_turnsBadgeOnWithoutReload() async {
-        XCTAssertFalse(sut.showsUnreadBadge)
+    func test_handleIncomingNotification_outsideNotificationTab_turnsBadgeOnWhenUnreadExists() async {
+        stub.fetchResult = .success([
+            makeAlarmResponse(alarmId: 7, alarmType: "FAILED", albumId: nil)
+        ])
 
         await sut.handleIncomingNotification(isViewingNotificationTab: false)
 
         XCTAssertTrue(sut.showsUnreadBadge)
-        XCTAssertTrue(sut.notifications.isEmpty)
+        XCTAssertEqual(sut.notifications.map(\.id), ["7"])
+    }
+
+    // 알림탭 밖에서 이미 읽은 알림만 있는 경우(시스템 알림센터 잔존 후 재탭 등) 배지 OFF 유지
+    func test_handleIncomingNotification_outsideNotificationTab_keepsBadgeOffWhenAllRead() async {
+        stub.fetchResult = .success([
+            makeAlarmResponse(alarmId: 7, alarmType: "FAILED", albumId: nil)
+        ])
+        await sut.loadNotifications()
+        sut.markAllAsRead()
+
+        await sut.handleIncomingNotification(isViewingNotificationTab: false)
+
+        XCTAssertFalse(sut.showsUnreadBadge)
     }
 
     func test_handleIncomingNotification_insideNotificationTab_reloadsListAndKeepsBadgeOff() async {
@@ -157,12 +172,33 @@ final class NotificationViewModelTests: XCTestCase {
     }
 
     func test_handleAppBecameActive_withoutDeliveredOrUnread_clearsBadge() async {
+        stub.fetchResult = .success([
+            makeAlarmResponse(alarmId: 7, alarmType: "FAILED", albumId: nil)
+        ])
         await sut.handleIncomingNotification(isViewingNotificationTab: false)
+        XCTAssertTrue(sut.showsUnreadBadge)
 
         stub.fetchResult = .success([])
         await sut.handleAppBecameActive(
             isViewingNotificationTab: false,
             hasDeliveredNotifications: false
+        )
+
+        XCTAssertFalse(sut.showsUnreadBadge)
+    }
+
+    // 알림센터에 푸시가 남아있어도 서버 기준 모두 읽음이면 최종 배지 OFF
+    // -> 알림센터 잔존 알림으로 배지 고착되는 문제 방지
+    func test_handleAppBecameActive_withDeliveredButAllRead_clearsBadge() async {
+        stub.fetchResult = .success([
+            makeAlarmResponse(alarmId: 7, alarmType: "FAILED", albumId: nil)
+        ])
+        await sut.loadNotifications()
+        sut.markAllAsRead()
+
+        await sut.handleAppBecameActive(
+            isViewingNotificationTab: false,
+            hasDeliveredNotifications: true
         )
 
         XCTAssertFalse(sut.showsUnreadBadge)


### PR DESCRIPTION
## 📄 작업 내용
- 레드닷 및 안읽음 배경색 표시 상태 개선

## 🔗 관련 이슈
<!-- ex) close #12 -->
close #98 

## ✅ 체크리스트
- [ ] 백그라운드 + 알림 탭 밖일 경우 표시
- [ ] 백그라운드 + 알림 탭일 경우 표시
- [ ] 포그라운드 + 알림 탭 밖일 경우 표시
- [ ] 포그라운드 + 알림 탭일 경우 표시
