### PR TITLE
fix(#127): Xcode Cloud 아카이브 시 Firebase Plist 중복 생성 충돌

### DIFF
--- a/VibeTrip.xcodeproj/project.pbxproj
+++ b/VibeTrip.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		F59BA9BA2F668A3000F9AAB0 /* Exceptions for "VibeTrip" folder in "VibeTrip" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				"GoogleService-Info.plist",
 				Info.plist,
 			);
 			target = F5D0104E2F52015C0007B939 /* VibeTrip */;


### PR DESCRIPTION


## 📄 작업 내용
- GA 의존성 추가 시 누락된 GoogleService-Info.plist 예외 항목을 복원

## 🔗 관련 이슈
<!-- ex) close #12 -->
close #127 

## ✅ 체크리스트
- [ ] 
