### PR TITLE
fix(#132): 로그 작성/수정 안정성 개선

### DIFF
--- a/VibeTrip/ViewModels/AlbumLogViewModel.swift
+++ b/VibeTrip/ViewModels/AlbumLogViewModel.swift
@@ -73,9 +73,9 @@ struct PhotoSlot: Identifiable {
     // 날짜 헤더 표시용 -> 생성: 작성 날짜, 수정: 로그 작성 날짜
     let createdDate: Date
 
-    // 저장 버튼 활성화 조건: 텍스트 1자 이상
+    // 저장 버튼 활성화 조건: 공백/개행 제외 1자 이상
     var isSaveEnabled: Bool {
-        !logText.isEmpty
+        !logText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     // 기존 + 신규 사진을 단일 리스트로 표현 (View -> ForEach 용)
@@ -178,7 +178,10 @@ struct PhotoSlot: Identifiable {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
         formatter.dateFormat = Constants.timeFormat
-        logText += "\(formatter.string(from: Date())) "
+        let stamp = "\(formatter.string(from: Date())) "
+        // 글자 수 제한 초과 시, 타임스탬프 입력 제한
+        guard logText.count + stamp.count <= Self.maxDescriptionLength else { return }
+        logText += stamp
     }
 
     // 사진 추가 -> 기존 + 신규 합산 5장 초과 시 토스트 표시
@@ -219,6 +222,7 @@ struct PhotoSlot: Identifiable {
 
     // 로그 저장 (작성: POST, 수정: PUT)
     func saveLog() async {
+        guard !isSaving else { return }
         let trimmedLogText = logText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedLogText.isEmpty else {
             showToast(Constants.saveValidationMessage)

--- a/VibeTrip/ViewModels/AlbumLogViewModel.swift
+++ b/VibeTrip/ViewModels/AlbumLogViewModel.swift
@@ -73,11 +73,6 @@ struct PhotoSlot: Identifiable {
     // 날짜 헤더 표시용 -> 생성: 작성 날짜, 수정: 로그 작성 날짜
     let createdDate: Date
 
-    // 저장 버튼 활성화 조건: 공백/개행 제외 1자 이상
-    var isSaveEnabled: Bool {
-        !logText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    }
-
     // 기존 + 신규 사진을 단일 리스트로 표현 (View -> ForEach 용)
     var photoSlots: [PhotoSlot] {
         let existing = existingPhotos.map { photo in

--- a/VibeTrip/ViewModels/AlbumLogViewModel.swift
+++ b/VibeTrip/ViewModels/AlbumLogViewModel.swift
@@ -9,24 +9,55 @@ import Foundation
 import Combine
 import UIKit
 
+// MARK: - Photo State Types
+
+// 서버에서 받아온 기존 사진
+// image -> 비동기 로딩 중/실패 시 nil 유지
+struct ExistingPhoto: Identifiable {
+    let id: Int64        // 서버 image id
+    let url: URL
+    var image: UIImage?
+}
+
+// 사용자가 이번 편집 세션에서 새로 추가한 사진
+struct NewPhoto: Identifiable {
+    let id: UUID = UUID()
+    let image: UIImage
+}
+
+// View 가 단일 리스트로 다루기 위한 표시 모델 (기존 + 신규 결합)
+struct PhotoSlot: Identifiable {
+    enum Kind {
+        case existing(id: Int64)
+        case new(id: UUID)
+    }
+    let id: String       // "existing-\(id)" / "new-\(uuid)" — ForEach 안정성
+    let kind: Kind
+    let image: UIImage?
+}
+
 @MainActor final class AlbumLogViewModel: ObservableObject {
-    
+
     // MARK: - LogViewMode
-    
+
     // 작성 및 수정 모드 분기
     enum LogViewMode {
         case create /// 작성
         case edit(AlbumLogEntry) /// 수정
     }
-    
+
     // MARK: - Published
-    
+
     // 텍스트 입력 내용
     @Published var logText: String = ""
     // 선택된 사진 목록 (수정 모드: 앞쪽 existingPhotosCount개가 기존 사진, 뒤쪽이 새 사진)
     @Published var selectedPhotos: [UIImage] = []
     // 기존 사진 수 (수정 모드에서 URL 로딩 완료 후 확정) —> 뷰에서 컨텍스트 메뉴 조건 판단에 사용
     @Published private(set) var existingPhotosCount: Int = 0
+    // 기존 사진 (서버 id 보존, 이미지 로딩은 비동기)
+    @Published private(set) var existingPhotos: [ExistingPhoto] = []
+    // 사용자가 이번 세션에서 새로 추가한 사진
+    @Published private(set) var newPhotos: [NewPhoto] = []
     // 하단 토스트 메시지
     @Published private(set) var toastMessage: String?
     // 종료 확인 팝업 표시 여부
@@ -46,6 +77,35 @@ import UIKit
     // 저장 버튼 활성화 조건: 텍스트 1자 이상
     var isSaveEnabled: Bool {
         !logText.isEmpty
+    }
+
+    // 기존 + 신규 사진을 단일 리스트로 표현 (View -> ForEach 용)
+    var photoSlots: [PhotoSlot] {
+        let existing = existingPhotos.map { photo in
+            PhotoSlot(
+                id: "existing-\(photo.id)",
+                kind: .existing(id: photo.id),
+                image: photo.image
+            )
+        }
+        let new = newPhotos.map { photo in
+            PhotoSlot(
+                id: "new-\(photo.id.uuidString)",
+                kind: .new(id: photo.id),
+                image: photo.image
+            )
+        }
+        return existing + new
+    }
+
+    // 총 사진 개수 (5장 제한 계산용)
+    var totalPhotoCount: Int {
+        existingPhotos.count + newPhotos.count
+    }
+
+    // 사진 보유 여부
+    var hasPhotos: Bool {
+        totalPhotoCount > 0
     }
 
     // 변경 감지: 이탈 팝업 노출 판단
@@ -110,6 +170,10 @@ import UIKit
             createdDate = ISO8601DateFormatter().date(from: entry.postedAt) ?? Date()
             existingPhotosCount = entry.images.count
             existingImageIds = entry.images.map(\.id)
+            // 서버 이미지 전체를 image: nil 슬롯으로 즉시 보유 (로딩은 비동기)
+            existingPhotos = entry.images.map {
+                ExistingPhoto(id: $0.id, url: $0.imageUrl, image: nil)
+            }
             Task { await loadExistingPhotos(from: entry.images.map(\.imageUrl)) }
         }
     }
@@ -138,7 +202,10 @@ import UIKit
             showToast(Constants.photoLimitMessage)
             return
         }
-        selectedPhotos.append(contentsOf: validImages.prefix(available))
+        let appended = Array(validImages.prefix(available))
+        selectedPhotos.append(contentsOf: appended)
+        // 신규 자료구조 동기화
+        newPhotos.append(contentsOf: appended.map { NewPhoto(image: $0) })
         if validImages.count > available {
             showToast(Constants.photoLimitMessage)
         }
@@ -148,16 +215,26 @@ import UIKit
     func removePhoto(at index: Int) {
         if index < existingPhotosCount {
             // 기존 사진 삭제: ID를 removedImageIds에 기록 후 existingImageIds에서 제거
-            removedImageIds.append(existingImageIds[index])
+            let removedId = existingImageIds[index]
+            removedImageIds.append(removedId)
             existingImageIds.remove(at: index)
             existingPhotosCount -= 1
             // selectedPhotos는 비동기 로딩 완료 후에만 존재
             if selectedPhotos.indices.contains(index) {
                 selectedPhotos.remove(at: index)
             }
+            // 신규 자료구조 동기화: 같은 id 항목 제거
+            if let idx = existingPhotos.firstIndex(where: { $0.id == removedId }) {
+                existingPhotos.remove(at: idx)
+            }
         } else {
             guard selectedPhotos.indices.contains(index) else { return }
             selectedPhotos.remove(at: index)
+            // 신규 자료구조 동기화: selectedPhotos 의 new 영역 인덱스 = index - existingPhotosCount
+            let newIndex = index - existingPhotosCount
+            if newPhotos.indices.contains(newIndex) {
+                newPhotos.remove(at: newIndex)
+            }
         }
     }
 
@@ -230,6 +307,10 @@ import UIKit
             if let (data, _) = try? await URLSession.shared.data(from: url),
                let image = UIImage(data: data) {
                 loaded.append(image)
+                // 신규 자료구조 동기화: 동일 url 슬롯에 image 채움 (도중 삭제 안전성 위해 재탐색)
+                if let idx = existingPhotos.firstIndex(where: { $0.url == url }) {
+                    existingPhotos[idx].image = image
+                }
             }
         }
         selectedPhotos.insert(contentsOf: loaded, at: 0)

--- a/VibeTrip/ViewModels/AlbumLogViewModel.swift
+++ b/VibeTrip/ViewModels/AlbumLogViewModel.swift
@@ -211,6 +211,36 @@ struct PhotoSlot: Identifiable {
         }
     }
 
+    // 슬롯 기반 사진 삭제: 서버 id / UUID 로 정확히 매칭해 잘못된 항목 삭제를 방지
+    func removePhoto(slot: PhotoSlot) {
+        switch slot.kind {
+        case .existing(let id):
+            guard let idx = existingPhotos.firstIndex(where: { $0.id == id }) else { return }
+            let hadImage = existingPhotos[idx].image != nil
+            // selectedPhotos 내 existing 영역에서의 위치: 자기보다 앞에 로드된 항목 수
+            let selectedIdx = existingPhotos[0..<idx].reduce(0) { $1.image != nil ? $0 + 1 : $0 }
+            existingPhotos.remove(at: idx)
+            if !removedImageIds.contains(id) {
+                removedImageIds.append(id)
+            }
+            if let oldIdsIdx = existingImageIds.firstIndex(of: id) {
+                existingImageIds.remove(at: oldIdsIdx)
+            }
+            if hadImage, selectedPhotos.indices.contains(selectedIdx) {
+                selectedPhotos.remove(at: selectedIdx)
+                existingPhotosCount = max(0, existingPhotosCount - 1)
+            }
+
+        case .new(let uuid):
+            guard let newIdx = newPhotos.firstIndex(where: { $0.id == uuid }) else { return }
+            newPhotos.remove(at: newIdx)
+            let selectedIdx = existingPhotosCount + newIdx
+            if selectedPhotos.indices.contains(selectedIdx) {
+                selectedPhotos.remove(at: selectedIdx)
+            }
+        }
+    }
+
     // 특정 인덱스 사진 삭제
     func removePhoto(at index: Int) {
         if index < existingPhotosCount {
@@ -268,10 +298,8 @@ struct PhotoSlot: Identifiable {
 
             case .edit:
                 guard let albumLogId else { return }
-                // 기존 사진 이후 인덱스만 새 사진으로 전송
-                let newPhotos = Array(selectedPhotos.dropFirst(existingPhotosCount))
                 let newPhotoDataList = newPhotos.compactMap {
-                    $0.jpegData(compressionQuality: 0.8)
+                    $0.image.jpegData(compressionQuality: 0.8)
                 }
                 let request = AlbumLogUpdateRequest(
                     albumId: albumId,

--- a/VibeTrip/ViewModels/AlbumLogViewModel.swift
+++ b/VibeTrip/ViewModels/AlbumLogViewModel.swift
@@ -50,10 +50,6 @@ struct PhotoSlot: Identifiable {
 
     // 텍스트 입력 내용
     @Published var logText: String = ""
-    // 선택된 사진 목록 (수정 모드: 앞쪽 existingPhotosCount개가 기존 사진, 뒤쪽이 새 사진)
-    @Published var selectedPhotos: [UIImage] = []
-    // 기존 사진 수 (수정 모드에서 URL 로딩 완료 후 확정) —> 뷰에서 컨텍스트 메뉴 조건 판단에 사용
-    @Published private(set) var existingPhotosCount: Int = 0
     // 기존 사진 (서버 id 보존, 이미지 로딩은 비동기)
     @Published private(set) var existingPhotos: [ExistingPhoto] = []
     // 사용자가 이번 세션에서 새로 추가한 사진
@@ -66,9 +62,9 @@ struct PhotoSlot: Identifiable {
     @Published private(set) var isSaving: Bool = false
     // 저장 성공 여부 (화면 전환 트리거)
     @Published private(set) var isSaved: Bool = false
-    
+
     // MARK: - Properties
-    
+
     let albumId: String
     let mode: LogViewMode
     // 날짜 헤더 표시용 -> 생성: 작성 날짜, 수정: 로그 작성 날짜
@@ -112,11 +108,10 @@ struct PhotoSlot: Identifiable {
     var hasUnsavedChanges: Bool {
         if logText != initialText { return true }
         switch mode {
-        case .create: return !selectedPhotos.isEmpty
+        case .create:
+            return !newPhotos.isEmpty
         case .edit:
-            let hasAddedPhotos = selectedPhotos.count > existingPhotosCount
-            let hasRemovedPhotos = !removedImageIds.isEmpty
-            return hasAddedPhotos || hasRemovedPhotos
+            return !newPhotos.isEmpty || !removedImageIds.isEmpty
         }
     }
 
@@ -125,8 +120,6 @@ struct PhotoSlot: Identifiable {
     private let service: AlbumServiceProtocol
     private let initialText: String
     private var albumLogId: Int?
-    // 현재 남아있는 기존 이미지 ID 목록
-    private var existingImageIds: [Int64] = []
     // 삭제된 기존 이미지 ID 목록 (PUT 요청 시 removeImageIds로 전달)
     private var removedImageIds: [Int64] = []
 
@@ -168,13 +161,11 @@ struct PhotoSlot: Identifiable {
             logText = prefilled
             initialText = prefilled
             createdDate = ISO8601DateFormatter().date(from: entry.postedAt) ?? Date()
-            existingPhotosCount = entry.images.count
-            existingImageIds = entry.images.map(\.id)
             // 서버 이미지 전체를 image: nil 슬롯으로 즉시 보유 (로딩은 비동기)
             existingPhotos = entry.images.map {
                 ExistingPhoto(id: $0.id, url: $0.imageUrl, image: nil)
             }
-            Task { await loadExistingPhotos(from: entry.images.map(\.imageUrl)) }
+            Task { await loadExistingPhotoImages() }
         }
     }
 
@@ -187,7 +178,7 @@ struct PhotoSlot: Identifiable {
         logText += "\(formatter.string(from: Date())) "
     }
 
-    // 사진 추가 -> 5장 초과 시 토스트 표시
+    // 사진 추가 -> 기존 + 신규 합산 5장 초과 시 토스트 표시
     func addPhotos(_ images: [UIImage]) {
         let validImages = images.filter { image in
             guard let data = image.jpegData(compressionQuality: 1.0) else { return false }
@@ -197,14 +188,12 @@ struct PhotoSlot: Identifiable {
             showToast(Constants.photoSizeLimitMessage)
         }
 
-        let available = Constants.maxPhotoCount - selectedPhotos.count
+        let available = Constants.maxPhotoCount - totalPhotoCount
         guard available > 0 else {
             showToast(Constants.photoLimitMessage)
             return
         }
         let appended = Array(validImages.prefix(available))
-        selectedPhotos.append(contentsOf: appended)
-        // 신규 자료구조 동기화
         newPhotos.append(contentsOf: appended.map { NewPhoto(image: $0) })
         if validImages.count > available {
             showToast(Constants.photoLimitMessage)
@@ -215,56 +204,13 @@ struct PhotoSlot: Identifiable {
     func removePhoto(slot: PhotoSlot) {
         switch slot.kind {
         case .existing(let id):
-            guard let idx = existingPhotos.firstIndex(where: { $0.id == id }) else { return }
-            let hadImage = existingPhotos[idx].image != nil
-            // selectedPhotos 내 existing 영역에서의 위치: 자기보다 앞에 로드된 항목 수
-            let selectedIdx = existingPhotos[0..<idx].reduce(0) { $1.image != nil ? $0 + 1 : $0 }
-            existingPhotos.remove(at: idx)
+            existingPhotos.removeAll { $0.id == id }
             if !removedImageIds.contains(id) {
                 removedImageIds.append(id)
             }
-            if let oldIdsIdx = existingImageIds.firstIndex(of: id) {
-                existingImageIds.remove(at: oldIdsIdx)
-            }
-            if hadImage, selectedPhotos.indices.contains(selectedIdx) {
-                selectedPhotos.remove(at: selectedIdx)
-                existingPhotosCount = max(0, existingPhotosCount - 1)
-            }
 
         case .new(let uuid):
-            guard let newIdx = newPhotos.firstIndex(where: { $0.id == uuid }) else { return }
-            newPhotos.remove(at: newIdx)
-            let selectedIdx = existingPhotosCount + newIdx
-            if selectedPhotos.indices.contains(selectedIdx) {
-                selectedPhotos.remove(at: selectedIdx)
-            }
-        }
-    }
-
-    // 특정 인덱스 사진 삭제
-    func removePhoto(at index: Int) {
-        if index < existingPhotosCount {
-            // 기존 사진 삭제: ID를 removedImageIds에 기록 후 existingImageIds에서 제거
-            let removedId = existingImageIds[index]
-            removedImageIds.append(removedId)
-            existingImageIds.remove(at: index)
-            existingPhotosCount -= 1
-            // selectedPhotos는 비동기 로딩 완료 후에만 존재
-            if selectedPhotos.indices.contains(index) {
-                selectedPhotos.remove(at: index)
-            }
-            // 신규 자료구조 동기화: 같은 id 항목 제거
-            if let idx = existingPhotos.firstIndex(where: { $0.id == removedId }) {
-                existingPhotos.remove(at: idx)
-            }
-        } else {
-            guard selectedPhotos.indices.contains(index) else { return }
-            selectedPhotos.remove(at: index)
-            // 신규 자료구조 동기화: selectedPhotos 의 new 영역 인덱스 = index - existingPhotosCount
-            let newIndex = index - existingPhotosCount
-            if newPhotos.indices.contains(newIndex) {
-                newPhotos.remove(at: newIndex)
-            }
+            newPhotos.removeAll { $0.id == uuid }
         }
     }
 
@@ -275,14 +221,14 @@ struct PhotoSlot: Identifiable {
             showToast(Constants.saveValidationMessage)
             return
         }
-        
+
         isSaving = true
         defer { isSaving = false }
         do {
             switch mode {
             case .create:
-                let photoDataList = selectedPhotos.compactMap {
-                    $0.jpegData(compressionQuality: 0.8)
+                let photoDataList = newPhotos.compactMap {
+                    $0.image.jpegData(compressionQuality: 0.8)
                 }
                 let request = AlbumLogRequest(
                     albumId: albumId,
@@ -293,7 +239,7 @@ struct PhotoSlot: Identifiable {
                 // 로그 작성 추적
                 analytics.log(.logSave, parameters: [
                     .charCount: trimmedLogText.count,
-                    .hasPhoto: !selectedPhotos.isEmpty
+                    .hasPhoto: hasPhotos
                 ])
 
             case .edit:
@@ -328,20 +274,18 @@ struct PhotoSlot: Identifiable {
 
     // MARK: - Private Methods
 
-    // 수정 모드: 기존 이미지 URL -> UIImage 로딩 (selectedPhotos 앞쪽에 삽입)
-    private func loadExistingPhotos(from urls: [URL]) async {
-        var loaded: [UIImage] = []
+    // 수정 모드: existingPhotos 각 슬롯의 이미지를 비동기로 채움
+    // 도중 삭제 안전성 위해 url 로 슬롯을 재탐색
+    private func loadExistingPhotoImages() async {
+        let urls = existingPhotos.map(\.url)
         for url in urls {
-            if let (data, _) = try? await URLSession.shared.data(from: url),
-               let image = UIImage(data: data) {
-                loaded.append(image)
-                // 신규 자료구조 동기화: 동일 url 슬롯에 image 채움 (도중 삭제 안전성 위해 재탐색)
-                if let idx = existingPhotos.firstIndex(where: { $0.url == url }) {
-                    existingPhotos[idx].image = image
-                }
+            guard let (data, _) = try? await URLSession.shared.data(from: url),
+                  let image = UIImage(data: data) else {
+                continue
+            }
+            if let idx = existingPhotos.firstIndex(where: { $0.url == url }) {
+                existingPhotos[idx].image = image
             }
         }
-        selectedPhotos.insert(contentsOf: loaded, at: 0)
-        existingPhotosCount = loaded.count  // 실제 로딩 성공한 수로 보정
     }
 }

--- a/VibeTrip/ViewModels/AlbumLogViewModel.swift
+++ b/VibeTrip/ViewModels/AlbumLogViewModel.swift
@@ -38,6 +38,9 @@ struct PhotoSlot: Identifiable {
 
 @MainActor final class AlbumLogViewModel: ObservableObject {
 
+    // 입력 가능한 최대 글자 수
+    static let maxDescriptionLength = 500
+
     // MARK: - LogViewMode
 
     // 작성 및 수정 모드 분기

--- a/VibeTrip/Views/AlbumDetailView.swift
+++ b/VibeTrip/Views/AlbumDetailView.swift
@@ -28,7 +28,8 @@ import Combine
     @Published private(set) var isDownloadingMusic: Bool = false
     @Published private(set) var downloadedMusicFileURL: URL? = nil  // 공유 시트 트리거
     @Published private(set) var isStorageFull: Bool = false
-    
+    @Published private(set) var awaitingImageLogIds: Set<Int> = []  // 방금 저장한 로그 중 이미지 응답이 아직 비어 있는 id 모음 -> 카드 이미지 영역을 스켈레톤으로 표시
+
     private let albumId: String
     private let albumIdInt: Int    // Int 변환값, init에서 1회만 처리
     private var cursor: Int? = nil
@@ -88,6 +89,37 @@ import Combine
         } catch {
             // 실패 시 기존 logs 유지. 사용자 알림은 별도 작업으로 분리됨
         }
+    }
+
+    // 저장 직후 호출: 목록을 재조회하고 이미지가 곧장 안 채워진 경우 짧은 backoff 로 폴링
+    // 대상 로그 카드의 이미지 영역만 스켈레톤으로 표시하고 나머지 영역/카드는 그대로 유지
+    func refreshAfterSave(info: SavedLogInfo) async {
+        await loadInitialLogs()
+        guard info.hasImages else { return }
+
+        // 어떤 id 를 기다릴 것인지 확정
+        let targetId: Int?
+        switch info.mode {
+        case .edit(let id):
+            targetId = id
+        case .create:
+            targetId = logs.first?.id
+        }
+        guard let id = targetId else { return }
+
+        // 이미 이미지가 채워졌으면 폴링 불필요
+        if let entry = logs.first(where: { $0.id == id }), !entry.images.isEmpty { return }
+
+        awaitingImageLogIds.insert(id)
+        defer { awaitingImageLogIds.remove(id) }
+
+        // backoff 폴링: 매 시도마다 첫 페이지 재조회 후 대상 id 의 images 채워졌는지 확인
+        for delay in [0.3, 0.8, 1.5] as [TimeInterval] {
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            await loadInitialLogs()
+            if let entry = logs.first(where: { $0.id == id }), !entry.images.isEmpty { return }
+        }
+        // 최대 시도 후에도 비어 있으면 스켈레톤만 사라짐 (사용자 재진입/새로고침으로 회복 가능)
     }
     
     // 음악 파일을 임시 폴더에 다운로드 후 공유 시트 트리거
@@ -298,8 +330,8 @@ struct AlbumDetailView: View {
     // 앨범 수정 화면 표시 여부
     @State private var isEditPresented: Bool = false
     
-    // 실제 저장 완료 여부: onDismiss 재조회 조건 판단
-    @State private var didSaveLog: Bool = false
+    // 실제 저장 완료 정보 (nil 이면 저장 없이 dismiss): onDismiss 재조회 + 이미지 영역 스켈레톤 처리에 사용
+    @State private var pendingSavedInfo: SavedLogInfo? = nil
     
     @EnvironmentObject private var musicService: BackgroundMusicService
     @EnvironmentObject private var appState: AppState
@@ -491,20 +523,20 @@ struct AlbumDetailView: View {
         .navigationBarBackButtonHidden(true)
         .toolbar(.hidden, for: .navigationBar)
         .fullScreenCover(item: $logPresentation, onDismiss: {
-            // 목록 재조회: 저장이 발생한 경우만
-            if didSaveLog {
-                Task { await logViewModel.loadInitialLogs() }
+            // 목록 재조회 + 이미지 영역 스켈레톤 처리: 저장이 발생한 경우만
+            if let info = pendingSavedInfo {
+                Task { await logViewModel.refreshAfterSave(info: info) }
                 // 메인 페이지 앨범 카드 미리보기 썸네일 갱신
                 appState.needsAlbumRefresh = true
             }
-            didSaveLog = false
+            pendingSavedInfo = nil
         }) { state in
             switch state {
             case .create:
-                AlbumLogView(albumId: String(displayModel.albumId), mode: .create, onSaved: { didSaveLog = true })
+                AlbumLogView(albumId: String(displayModel.albumId), mode: .create) { info in pendingSavedInfo = info }
                     .environmentObject(musicService)
             case .edit(let entry):
-                AlbumLogView(albumId: String(displayModel.albumId), mode: .edit(entry), onSaved: { didSaveLog = true })
+                AlbumLogView(albumId: String(displayModel.albumId), mode: .edit(entry)) { info in pendingSavedInfo = info }
                     .environmentObject(musicService)
             }
         }
@@ -1424,7 +1456,8 @@ private struct AlbumDetailLogFeedSection: View {
                     onDeleteLog: { logId in
                         viewModel.requestDeleteLog(id: logId)
                     },
-                    onEdit: onEdit
+                    onEdit: onEdit,
+                    awaitingImageLogIds: viewModel.awaitingImageLogIds
                 )
             }
         }
@@ -1445,12 +1478,13 @@ private struct AlbumDetailLogDateGroup: View {
     let onLastAppear: (() async -> Void)?
     let onDeleteLog: (Int) -> Void
     let onEdit: (AlbumLogEntry) -> Void
-    
+    let awaitingImageLogIds: Set<Int>
+
     private enum Constants {
         /// 로그 카드 간 간격
         static let itemSpacing: CGFloat = 20
     }
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: Constants.itemSpacing) {
             ForEach(entries) { entry in
@@ -1459,7 +1493,8 @@ private struct AlbumDetailLogDateGroup: View {
                     isLast: entry.id == lastEntryId,
                     onLastAppear: onLastAppear,
                     onDeleteLog: onDeleteLog,
-                    onEdit: onEdit
+                    onEdit: onEdit,
+                    showSkeletonIfNoImages: awaitingImageLogIds.contains(entry.id)
                 )
             }
         }
@@ -1475,6 +1510,8 @@ private struct AlbumDetailLogItemCard: View {
     let onLastAppear: (() async -> Void)?
     let onDeleteLog: (Int) -> Void
     let onEdit: (AlbumLogEntry) -> Void
+    // 방금 저장한 로그처럼 이미지 응답이 비어 있을 때 슬라이더 자리에 스켈레톤을 그릴지 여부
+    let showSkeletonIfNoImages: Bool
     
     /// 로그 옵션 팝업 표시 여부
     @State private var isMenuVisible: Bool = false
@@ -1528,9 +1565,12 @@ private struct AlbumDetailLogItemCard: View {
                     .padding(.trailing, -4)
                 }
                 
-                // 이미지 슬라이더 (이미지 있을 때만)
+                // 이미지 슬라이더: 이미지 있을 때 본 슬라이더, 응답 대기 중인 로그는 스켈레톤
                 if !entry.images.isEmpty {
                     AlbumDetailLogImageSlider(images: entry.images)
+                        .padding(.top, Constants.dateToImageSpacing)
+                } else if showSkeletonIfNoImages {
+                    AlbumDetailLogImageSkeleton()
                         .padding(.top, Constants.dateToImageSpacing)
                 }
                 
@@ -1645,6 +1685,27 @@ private struct AlbumDetailLogImageSlider: View {
         }
         .frame(maxWidth: .infinity)
         .frame(height: Constants.sliderHeight)
+    }
+}
+
+// MARK: - AlbumDetailLogImageSkeleton
+// 이미지 응답 대기 중인 로그 카드의 슬라이더 자리에 표시하는 shimmer placeholder
+// 슬라이더와 동일 치수로 그려 카드 레이아웃이 흔들리지 않게 함
+
+private struct AlbumDetailLogImageSkeleton: View {
+    private enum Constants {
+        static let cornerRadius: CGFloat = 16
+        static var sliderHeight: CGFloat {
+            (UIScreen.main.bounds.width - 40) * 3 / 4
+        }
+    }
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: Constants.cornerRadius)
+            .fill(Color.secondary.opacity(0.12))
+            .frame(maxWidth: .infinity)
+            .frame(height: Constants.sliderHeight)
+            .shimmering(shape: RoundedRectangle(cornerRadius: Constants.cornerRadius))
     }
 }
 

--- a/VibeTrip/Views/AlbumDetailView.swift
+++ b/VibeTrip/Views/AlbumDetailView.swift
@@ -34,6 +34,8 @@ import Combine
     private var cursor: Int? = nil
     private let limit = 20
     private let service: AlbumServiceProtocol
+    // 초기 로드 Task: 새 호출 시 이전 진행 중 fetch 를 cancel 해 race 로 인한 조용한 스킵 방지
+    private var loadTask: Task<Void, Never>? = nil
     // 밀리초 포함 ISO8601 파싱
     private static let isoFormatterWithFractionalSeconds: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
@@ -57,11 +59,35 @@ import Combine
         self.init(albumId: albumId, service: AlbumService())
     }
     
+    // 초기 페이지 로드: 진행 중 fetch 를 cancel 한 뒤 새 fetch 시작 -> race 로 인한 스킵 방지
+    // 실패 시 기존 logs 유지 -> 로그 목록 화면 깜빡임 방지
     func loadInitialLogs() async {
-        guard !isLoading else { return }
-        cursor = nil
-        logs = []
-        await fetchLogs()
+        loadTask?.cancel()
+        let task = Task { await performInitialLoad() }
+        loadTask = task
+        await task.value
+    }
+
+    private func performInitialLoad() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let payload = try await service.fetchAlbumLogs(albumId: albumId, cursor: nil, limit: limit)
+            try Task.checkCancellation()
+            for log in payload.content {
+                print("[AlbumLog] id:\(log.id) postedAt:\(log.postedAt) parsedDate:\(String(describing: Self.parseISO8601Date(log.postedAt)))")
+                // 저장 직후 사진 미표시 원인 진단용: 응답에 images 가 비어 오는지(케이스 ①) 확인
+                print("[AlbumLog] id:\(log.id) images.count:\(log.images.count) urls:\(log.images.map(\.imageUrl.absoluteString))")
+            }
+            // 성공 시점에만 교체: 사전 클리어 X -> 실패 시 기존 목록 유지
+            cursor = payload.content.last?.id
+            hasNext = payload.hasNext
+            logs = payload.content
+        } catch is CancellationError {
+            return
+        } catch {
+            // 실패 시 기존 logs 유지. 사용자 알림은 별도 작업으로 분리됨
+        }
     }
     
     // 음악 파일을 임시 폴더에 다운로드 후 공유 시트 트리거

--- a/VibeTrip/Views/AlbumLogView.swift
+++ b/VibeTrip/Views/AlbumLogView.swift
@@ -345,10 +345,6 @@ private extension AlbumLogView {
 
                 Spacer()
 
-                // [DEBUG] 입력 글자 수 카운터 (테스트용)
-                Text("\(viewModel.logText.count)자")
-                    .font(.setPretendard(weight: .regular, size: 12))
-                    .foregroundStyle(Color("GrayScale/300"))
             }
             .padding(.horizontal, Constants.contentHorizontalPadding)
             .frame(height: Constants.toolbarHeight - 1)

--- a/VibeTrip/Views/AlbumLogView.swift
+++ b/VibeTrip/Views/AlbumLogView.swift
@@ -282,7 +282,11 @@ private extension AlbumLogView {
                     .padding(.top, Constants.textEditorTopPadding)
             }
 
-            GrowingTextEditor(text: $viewModel.logText, isFocused: $isFocused)
+            GrowingTextEditor(
+                text: $viewModel.logText,
+                isFocused: $isFocused,
+                maxLength: AlbumLogViewModel.maxDescriptionLength
+            )
                 .frame(maxWidth: .infinity, minHeight: Constants.textEditorMinHeight, alignment: .top)
                 .padding(.horizontal, Constants.contentHorizontalPadding)
                 .padding(.top, Constants.textEditorTopPadding)

--- a/VibeTrip/Views/AlbumLogView.swift
+++ b/VibeTrip/Views/AlbumLogView.swift
@@ -129,13 +129,15 @@ struct AlbumLogView: View {
                                 .foregroundStyle(Color.appPrimary)
                         }
                     }
-                    .disabled(!viewModel.isSaveEnabled || viewModel.isSaving)
+                    .disabled(viewModel.isSaving)
                 }
             }
             .safeAreaInset(edge: .bottom, spacing: 0) {
                 // 하단 툴바
                 bottomToolbar
             }
+            // 저장 중에는 뒤로가기/텍스트/사진 영역까지 모든 입력 차단
+            .allowsHitTesting(!viewModel.isSaving)
 
             // 종료 확인 팝업
             if viewModel.isExitAlertPresented {

--- a/VibeTrip/Views/AlbumLogView.swift
+++ b/VibeTrip/Views/AlbumLogView.swift
@@ -129,7 +129,7 @@ struct AlbumLogView: View {
                                 .foregroundStyle(Color.appPrimary)
                         }
                     }
-                    .disabled(viewModel.isSaving)
+                    .disabled(!viewModel.isSaveEnabled || viewModel.isSaving)
                 }
             }
             .safeAreaInset(edge: .bottom, spacing: 0) {

--- a/VibeTrip/Views/AlbumLogView.swift
+++ b/VibeTrip/Views/AlbumLogView.swift
@@ -7,6 +7,18 @@
 
 import SwiftUI
 
+// MARK: - SavedLogInfo
+// 저장 완료 시 호출자에게 전달되는 정보 (작성/수정 구분 + 이미지 첨부 여부)
+// AlbumDetailView 가 방금 저장한 로그의 이미지 영역에 스켈레톤을 표시할지 판단할 때 사용
+struct SavedLogInfo {
+    enum SavedMode {
+        case create
+        case edit(logId: Int)
+    }
+    let mode: SavedMode
+    let hasImages: Bool
+}
+
 // MARK: - AlbumLogView
 
 struct AlbumLogView: View {
@@ -14,8 +26,8 @@ struct AlbumLogView: View {
     @StateObject private var viewModel: AlbumLogViewModel
     @Environment(\.dismiss) private var dismiss
 
-    // 저장 완료 시 호출 (목록 재조회 여부 판단에 사용)
-    private let onSaved: (() -> Void)?
+    // 저장 완료 시 호출 (저장 모드/이미지 첨부 여부를 전달해 후속 처리에 사용)
+    private let onSaved: ((SavedLogInfo) -> Void)?
 
     // 로그 입력 포커스 제어 (GrowingTextEditor 양방향 바인딩 + scrollDismissesKeyboard 연동)
     @State private var isFocused: Bool = false
@@ -65,7 +77,7 @@ struct AlbumLogView: View {
     // MARK: - Init
 
     @MainActor
-    init(albumId: String, mode: AlbumLogViewModel.LogViewMode, onSaved: (() -> Void)? = nil) {
+    init(albumId: String, mode: AlbumLogViewModel.LogViewMode, onSaved: ((SavedLogInfo) -> Void)? = nil) {
         self.onSaved = onSaved
         _viewModel = StateObject(
             wrappedValue: AlbumLogViewModel(
@@ -162,7 +174,15 @@ struct AlbumLogView: View {
         }
         .onChange(of: viewModel.isSaved) { _, saved in
             guard saved else { return }
-            onSaved?()
+            // 저장 모드와 이미지 첨부 여부를 호출자에게 넘겨 사후 처리에 활용
+            let savedMode: SavedLogInfo.SavedMode = {
+                switch viewModel.mode {
+                case .create:           return .create
+                case .edit(let entry):  return .edit(logId: entry.id)
+                }
+            }()
+            let info = SavedLogInfo(mode: savedMode, hasImages: !viewModel.selectedPhotos.isEmpty)
+            onSaved?(info)
             dismiss()
         }
         .onChange(of: viewModel.toastMessage) { _, message in
@@ -323,6 +343,11 @@ private extension AlbumLogView {
                 .disabled(viewModel.isSaving)
 
                 Spacer()
+
+                // [DEBUG] 입력 글자 수 카운터 (테스트용)
+                Text("\(viewModel.logText.count)자")
+                    .font(.setPretendard(weight: .regular, size: 12))
+                    .foregroundStyle(Color("GrayScale/300"))
             }
             .padding(.horizontal, Constants.contentHorizontalPadding)
             .frame(height: Constants.toolbarHeight - 1)

--- a/VibeTrip/Views/AlbumLogView.swift
+++ b/VibeTrip/Views/AlbumLogView.swift
@@ -17,10 +17,10 @@ struct AlbumLogView: View {
     // 저장 완료 시 호출 (목록 재조회 여부 판단에 사용)
     private let onSaved: (() -> Void)?
 
-    // TextEditor 포커스 제어 (scrollDismissesKeyboard 연동)
-    @FocusState private var isFocused: Bool
+    // 로그 입력 포커스 제어 (GrowingTextEditor 양방향 바인딩 + scrollDismissesKeyboard 연동)
+    @State private var isFocused: Bool = false
 
-    // 키보드 높이 추적 (커서 추적 스크롤에 사용)
+    // 키보드 높이 추적 (입력 영역이 키보드 위까지 스크롤 가능하도록 콘텐츠 하단 여백에 반영)
     @State private var keyboardHeight: CGFloat = 0
 
     // 보고 있는 사진 위치 관리
@@ -54,7 +54,6 @@ struct AlbumLogView: View {
         
         static let textEditorMinHeight: CGFloat = 200
         static let textEditorTopPadding: CGFloat = 20
-        static let textEditorInsetCorrection: CGFloat = 5
         // 페이지 인디케이터
         static let dotSize: CGFloat = 6                
         static let dotSpacing: CGFloat = 6
@@ -83,67 +82,47 @@ struct AlbumLogView: View {
     var body: some View {
         ZStack(alignment: .bottom) {
             // 메인 콘텐츠 스크롤 영역
-            ScrollViewReader { proxy in
-                ScrollView {
-                    VStack(spacing: 0) {
-                        dateHeader
+            ScrollView {
+                VStack(spacing: 0) {
+                    dateHeader
 
-                        // 사진이 있을 때만 사진 슬라이드 영역 표시
-                        if !viewModel.selectedPhotos.isEmpty {
-                            photoArea
-                        }
+                    // 사진이 있을 때만 사진 슬라이드 영역 표시
+                    if !viewModel.selectedPhotos.isEmpty {
+                        photoArea
+                    }
 
-                        textEditorArea
-                            .id("textEditor")   // 커서 추적 스크롤 앵커
-                    }
-                    // 빈 영역 탭으로 키보드 비활성화
-                    .contentShape(Rectangle())
-                    // 키보드 높이만큼 여백 추가 -> 커서가 키보드 뒤로 숨지 않게 설정
-                    .padding(.bottom, keyboardHeight)
+                    textEditorArea
                 }
-                .scrollDismissesKeyboard(.interactively)
-                .onTapGesture { isFocused = false }     // 화면 탭 시 키보드 해제
-                .safeAreaInset(edge: .top, spacing: 0) { // bottomToolbar 영역 확보 + 키보드 올라올 때 툴바도 함께 이동
-                    // AppNavigationBar: 상단 safe area에 고정
-                    // trailing에 저장 버튼 주입
-                    AppNavigationBar(title: navTitle, style: .solidWhite, onBackTap: handleBackButton) {
-                        Button {
-                            Task { await viewModel.saveLog() }
-                        } label: {
-                            if viewModel.isSaving {
-                                ProgressView()
-                                    .tint(Color.appPrimary)
-                                    .frame(width: 44, height: 44)
-                            } else {
-                                Text("저장")
-                                    .font(.setPretendard(weight: .semiBold, size: 16))
-                                    .foregroundStyle(Color.appPrimary)
-                            }
-                        }
-                        .disabled(viewModel.isSaving)
-                    }
-                }
-                .safeAreaInset(edge: .bottom, spacing: 0) {
-                    // 하단 툴바
-                    bottomToolbar
-                }
-                // 포커스 진입 시: 키보드 올라오는 시간(350ms)을 기다렸다가 스크롤
-                .onChange(of: isFocused) { _, focused in
-                    guard focused else { return }
-                    Task {
-                        try? await Task.sleep(for: .milliseconds(350))
-                        withAnimation(.easeOut(duration: 0.25)) {
-                            proxy.scrollTo("textEditor", anchor: .bottom)
+                // 빈 영역 탭으로 키보드 비활성화
+                .contentShape(Rectangle())
+                // 키보드 높이만큼 여백 추가 -> 입력 영역이 키보드 위까지 스크롤되도록 콘텐츠 확장
+                .padding(.bottom, keyboardHeight)
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .onTapGesture { isFocused = false }     // 화면 탭 시 키보드 해제
+            .safeAreaInset(edge: .top, spacing: 0) { // bottomToolbar 영역 확보 + 키보드 올라올 때 툴바도 함께 이동
+                // AppNavigationBar: 상단 safe area에 고정
+                // trailing에 저장 버튼 주입
+                AppNavigationBar(title: navTitle, style: .solidWhite, onBackTap: handleBackButton) {
+                    Button {
+                        Task { await viewModel.saveLog() }
+                    } label: {
+                        if viewModel.isSaving {
+                            ProgressView()
+                                .tint(Color.appPrimary)
+                                .frame(width: 44, height: 44)
+                        } else {
+                            Text("저장")
+                                .font(.setPretendard(weight: .semiBold, size: 16))
+                                .foregroundStyle(Color.appPrimary)
                         }
                     }
+                    .disabled(viewModel.isSaving)
                 }
-                // 타이핑/줄바꿈 감지: 키보드가 올라와 있을 때만 즉시 커서 위치로 스크롤
-                .onChange(of: viewModel.logText) { _, _ in
-                    guard isFocused, keyboardHeight > 0 else { return }
-                    withAnimation(.easeOut(duration: 0.1)) {
-                        proxy.scrollTo("textEditor", anchor: .bottom)
-                    }
-                }
+            }
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                // 하단 툴바
+                bottomToolbar
             }
 
             // 종료 확인 팝업
@@ -276,7 +255,7 @@ private extension AlbumLogView {
         .padding(.vertical, Constants.indicatorPaddingV)
     }
 
-    // TextEditor 입력 필드
+    // 로그 본문 입력 필드 (텍스트 양에 따라 자체 높이가 늘어나며 외곽 ScrollView가 전체 스크롤을 담당)
     var textEditorArea: some View {
         ZStack(alignment: .topLeading) {
             if viewModel.logText.isEmpty {
@@ -288,15 +267,10 @@ private extension AlbumLogView {
                     .padding(.top, Constants.textEditorTopPadding)
             }
 
-            TextEditor(text: $viewModel.logText)
-                .font(.setPretendard(weight: .regular, size: 16))
-                .lineSpacing(8)
-                .focused($isFocused)
-                .scrollContentBackground(.hidden)
-                .background(Color.clear)
-                .padding(.horizontal, Constants.contentHorizontalPadding - Constants.textEditorInsetCorrection)
-                .padding(.top, Constants.textEditorTopPadding - Constants.textEditorInsetCorrection)
+            GrowingTextEditor(text: $viewModel.logText, isFocused: $isFocused)
                 .frame(minHeight: Constants.textEditorMinHeight)
+                .padding(.horizontal, Constants.contentHorizontalPadding)
+                .padding(.top, Constants.textEditorTopPadding)
         }
     }
     

--- a/VibeTrip/Views/AlbumLogView.swift
+++ b/VibeTrip/Views/AlbumLogView.swift
@@ -99,7 +99,7 @@ struct AlbumLogView: View {
                     dateHeader
 
                     // 사진이 있을 때만 사진 슬라이드 영역 표시
-                    if !viewModel.selectedPhotos.isEmpty {
+                    if viewModel.hasPhotos {
                         photoArea
                     }
 
@@ -181,7 +181,7 @@ struct AlbumLogView: View {
                 case .edit(let entry):  return .edit(logId: entry.id)
                 }
             }()
-            let info = SavedLogInfo(mode: savedMode, hasImages: !viewModel.selectedPhotos.isEmpty)
+            let info = SavedLogInfo(mode: savedMode, hasImages: viewModel.hasPhotos)
             onSaved?(info)
             dismiss()
         }
@@ -218,25 +218,20 @@ private extension AlbumLogView {
     // 사진 슬라이드 영역
     var photoArea: some View {
         TabView(selection: $currentPhotoIndex) {
-            ForEach(viewModel.selectedPhotos.indices, id: \.self) { index in
+            ForEach(Array(viewModel.photoSlots.enumerated()), id: \.element.id) { index, slot in
                 GeometryReader { geometry in
-                    Image(uiImage: viewModel.selectedPhotos[index])
-                        .resizable()
-                        .frame(
-                            width: geometry.size.width,
-                            height: geometry.size.height
-                        )
+                    photoSlotImage(slot: slot, size: geometry.size)
                         // 이미지 영역 전체에서 컨텍스트 메뉴가 열리도록 터치 범위를 지정
                         .contentShape(Rectangle())
                         // 길게 누르면 프리뷰와 삭제 메뉴를 표시
                         .contextMenu {
                             Button(role: .destructive) {
-                                removePhoto(at: index)
+                                removePhoto(slot: slot)
                             } label: {
                                 Label("삭제", systemImage: "trash")
                             }
                         } preview: {
-                            photoPreview(for: index)
+                            photoPreview(for: slot)
                         }
                 }
                 .tag(index)
@@ -246,7 +241,7 @@ private extension AlbumLogView {
         .frame(height: Constants.photoAreaHeight)
         .overlay(alignment: .bottom) {
             // 사진 2장 이상일 때만 커스텀 인디케이터 표시
-            if viewModel.selectedPhotos.count > 1 {
+            if viewModel.totalPhotoCount > 1 {
                 pageIndicator
                     .padding(.bottom, Constants.indicatorBottomPadding)
             }
@@ -265,7 +260,7 @@ private extension AlbumLogView {
     // 커스텀 페이지 인디케이터
     private var pageIndicator: some View {
         HStack(spacing: Constants.dotSpacing) {
-            ForEach(viewModel.selectedPhotos.indices, id: \.self) { i in
+            ForEach(0..<viewModel.totalPhotoCount, id: \.self) { i in
                 Circle()
                     .frame(width: Constants.dotSize, height: Constants.dotSize)
                     .foregroundStyle(i == currentPhotoIndex ? Color.appPrimary : Color.white)
@@ -295,9 +290,9 @@ private extension AlbumLogView {
     }
     
     var placeholderText: String {
-        viewModel.selectedPhotos.isEmpty
-        ? "여행지에서 느꼈던 추억을 기록해보세요."
-        : "여행 기록을 저장하려면 짧은 이야기를 작성해주세요."
+        viewModel.hasPhotos
+        ? "여행 기록을 저장하려면 짧은 이야기를 작성해주세요."
+        : "여행지에서 느꼈던 추억을 기록해보세요."
     }
     
     var toastBottomPaddingFromToolbar: CGFloat {
@@ -414,11 +409,25 @@ private extension AlbumLogView {
         }
     }
 
+    // 슬롯 이미지 (이미지가 아직 로딩 중이면 placeholder)
+    @ViewBuilder
+    func photoSlotImage(slot: PhotoSlot, size: CGSize) -> some View {
+        if let image = slot.image {
+            Image(uiImage: image)
+                .resizable()
+                .frame(width: size.width, height: size.height)
+        } else {
+            Rectangle()
+                .fill(Color.secondary.opacity(0.12))
+                .frame(width: size.width, height: size.height)
+        }
+    }
+
     // 컨텍스트 메뉴 -> 프리뷰
     @ViewBuilder
-    func photoPreview(for index: Int) -> some View {
-        if viewModel.selectedPhotos.indices.contains(index) {
-            Image(uiImage: viewModel.selectedPhotos[index])
+    func photoPreview(for slot: PhotoSlot) -> some View {
+        if let image = slot.image {
+            Image(uiImage: image)
                 .resizable()
                 .scaledToFit()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -427,13 +436,14 @@ private extension AlbumLogView {
     }
 
     // 선택한 사진을 즉시 제거하고 현재 페이지 인덱스를 보정
-    func removePhoto(at index: Int) {
-        viewModel.removePhoto(at: index)
+    func removePhoto(slot: PhotoSlot) {
+        viewModel.removePhoto(slot: slot)
 
-        if viewModel.selectedPhotos.isEmpty {
+        let remaining = viewModel.totalPhotoCount
+        if remaining == 0 {
             currentPhotoIndex = 0
         } else {
-            currentPhotoIndex = min(currentPhotoIndex, viewModel.selectedPhotos.count - 1)
+            currentPhotoIndex = min(currentPhotoIndex, remaining - 1)
         }
     }
 }

--- a/VibeTrip/Views/AlbumLogView.swift
+++ b/VibeTrip/Views/AlbumLogView.swift
@@ -166,7 +166,7 @@ struct AlbumLogView: View {
             // OrderedPhotoPicker: 선택 순서 -> 번호로 보여주고 UIImage 배열 반환
             OrderedPhotoPicker(
                 isPresented: $isPhotoPickerPresented,
-                maxSelectionCount: max(1, 5 - viewModel.selectedPhotos.count)
+                maxSelectionCount: max(1, 5 - viewModel.totalPhotoCount)
             ) { images in
                 viewModel.addPhotos(images)
             }
@@ -309,7 +309,7 @@ private extension AlbumLogView {
             HStack(spacing: Constants.toolbarIconSpacing) {
                 // 카메라 아이콘
                 Button {
-                    guard viewModel.selectedPhotos.count < 5 else {
+                    guard viewModel.totalPhotoCount < 5 else {
                         viewModel.showToast("사진은 최대 5장까지 고를 수 있어요")
                         return
                     }

--- a/VibeTrip/Views/AlbumLogView.swift
+++ b/VibeTrip/Views/AlbumLogView.swift
@@ -268,7 +268,7 @@ private extension AlbumLogView {
             }
 
             GrowingTextEditor(text: $viewModel.logText, isFocused: $isFocused)
-                .frame(minHeight: Constants.textEditorMinHeight)
+                .frame(maxWidth: .infinity, minHeight: Constants.textEditorMinHeight, alignment: .top)
                 .padding(.horizontal, Constants.contentHorizontalPadding)
                 .padding(.top, Constants.textEditorTopPadding)
         }

--- a/VibeTrip/Views/Components/GrowingTextEditor.swift
+++ b/VibeTrip/Views/Components/GrowingTextEditor.swift
@@ -22,6 +22,11 @@ struct GrowingTextEditor: UIViewRepresentable {
     let textColor: UIColor
     let textContainerInset: UIEdgeInsets
 
+    // MARK: - Constraints
+
+    // 입력 가능한 최대 글자 수
+    let maxLength: Int?
+
     // MARK: - Init
 
     init(
@@ -30,7 +35,8 @@ struct GrowingTextEditor: UIViewRepresentable {
         font: UIFont = UIFont(name: "Pretendard-Regular", size: 16) ?? .systemFont(ofSize: 16),
         lineSpacing: CGFloat = 8,
         textColor: UIColor = .label,
-        textContainerInset: UIEdgeInsets = .zero
+        textContainerInset: UIEdgeInsets = .zero,
+        maxLength: Int? = nil
     ) {
         _text = text
         _isFocused = isFocused
@@ -38,6 +44,7 @@ struct GrowingTextEditor: UIViewRepresentable {
         self.lineSpacing = lineSpacing
         self.textColor = textColor
         self.textContainerInset = textContainerInset
+        self.maxLength = maxLength
     }
 
     // MARK: - UIViewRepresentable
@@ -116,8 +123,24 @@ struct GrowingTextEditor: UIViewRepresentable {
             self.parent = parent
         }
 
+        // 입력 전 단계에서 maxLength 초과 분량은 차단
+        func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+            if textView.markedTextRange != nil { return true }
+            guard let maxLength = parent.maxLength else { return true }
+            let current = textView.text ?? ""
+            guard let swiftRange = Range(range, in: current) else { return true }
+            let after = current.replacingCharacters(in: swiftRange, with: text)
+            return after.count <= maxLength
+        }
+
         // 사용자 입력 -> 외부 text 바인딩 갱신
+        // 조합 종료 시점에 maxLength 초과 상태면 prefix 로 잘라 정합화
         func textViewDidChange(_ textView: UITextView) {
+            if let maxLength = parent.maxLength,
+               textView.markedTextRange == nil,
+               (textView.text?.count ?? 0) > maxLength {
+                textView.text = String((textView.text ?? "").prefix(maxLength))
+            }
             parent.text = textView.text
         }
 

--- a/VibeTrip/Views/Components/GrowingTextEditor.swift
+++ b/VibeTrip/Views/Components/GrowingTextEditor.swift
@@ -49,6 +49,9 @@ struct GrowingTextEditor: UIViewRepresentable {
         textView.delegate = context.coordinator
         // intrinsicContentSize -> 텍스트 양에 따라 늘어남
         textView.isScrollEnabled = false
+        // UITextView는 UIScrollView 서브클래스라 부모 safe area를 contentInset으로 자동 반영 -> 빈 상태에서 캐럿 시작 위치가 아래로 밀리는 원인이라 명시적으로 차단
+        textView.contentInsetAdjustmentBehavior = .never
+        textView.contentInset = .zero
         textView.backgroundColor = .clear
         textView.textContainerInset = textContainerInset
         // 좌우 기본 inset 제거 -> 외부 SwiftUI padding으로 시각 위치 일원화

--- a/VibeTrip/Views/Components/GrowingTextEditor.swift
+++ b/VibeTrip/Views/Components/GrowingTextEditor.swift
@@ -1,0 +1,168 @@
+//
+//  GrowingTextEditor.swift
+//  VibeTrip
+//
+//  Created by CHOI on 5/26/26.
+//
+
+import SwiftUI
+import UIKit
+
+struct GrowingTextEditor: UIViewRepresentable {
+
+    // MARK: - Bindings
+
+    @Binding var text: String
+    @Binding var isFocused: Bool
+
+    // MARK: - Style
+
+    let font: UIFont
+    let lineSpacing: CGFloat
+    let textColor: UIColor
+    let textContainerInset: UIEdgeInsets
+
+    // MARK: - Init
+
+    init(
+        text: Binding<String>,
+        isFocused: Binding<Bool>,
+        font: UIFont = UIFont(name: "Pretendard-Regular", size: 16) ?? .systemFont(ofSize: 16),
+        lineSpacing: CGFloat = 8,
+        textColor: UIColor = .label,
+        textContainerInset: UIEdgeInsets = .zero
+    ) {
+        _text = text
+        _isFocused = isFocused
+        self.font = font
+        self.lineSpacing = lineSpacing
+        self.textColor = textColor
+        self.textContainerInset = textContainerInset
+    }
+
+    // MARK: - UIViewRepresentable
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    func makeUIView(context: Context) -> UITextView {
+        let textView = UITextView()
+        textView.delegate = context.coordinator
+        // intrinsicContentSize -> 텍스트 양에 따라 늘어남
+        textView.isScrollEnabled = false
+        textView.backgroundColor = .clear
+        textView.textContainerInset = textContainerInset
+        // 좌우 기본 inset 제거 -> 외부 SwiftUI padding으로 시각 위치 일원화
+        textView.textContainer.lineFragmentPadding = 0
+        textView.adjustsFontForContentSizeCategory = false
+        textView.font = font
+        textView.textColor = textColor
+        // 외곽 ScrollView 안에서 높이 압축 방지
+        textView.setContentCompressionResistancePriority(.required, for: .vertical)
+        // 새로 타이핑되는 글자도 동일 줄간격 유지
+        textView.typingAttributes = Self.makeAttributes(font: font, lineSpacing: lineSpacing, textColor: textColor)
+        return textView
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        // 외부 text가 내부와 다를 때만 갱신 -> 한글 조합 중 IME 깨짐/커서 점프 방지
+        if uiView.text != text {
+            uiView.attributedText = NSAttributedString(
+                string: text,
+                attributes: Self.makeAttributes(font: font, lineSpacing: lineSpacing, textColor: textColor)
+            )
+            // attributedText 설정 후에도 새 입력에 줄간격이 유지되도록 재설정
+            uiView.typingAttributes = Self.makeAttributes(font: font, lineSpacing: lineSpacing, textColor: textColor)
+        }
+
+        // 포커스 동기화: 외부 isFocused 변경을 first responder 상태에 반영
+        // 업데이트 사이클과 충돌 방지를 위해 async로 호출
+        if isFocused && !uiView.isFirstResponder {
+            DispatchQueue.main.async { uiView.becomeFirstResponder() }
+        } else if !isFocused && uiView.isFirstResponder {
+            DispatchQueue.main.async { uiView.resignFirstResponder() }
+        }
+    }
+
+    // MARK: - Helpers
+
+    // 폰트/줄간격/색상을 묶은 공통 속성 생성
+    private static func makeAttributes(font: UIFont, lineSpacing: CGFloat, textColor: UIColor) -> [NSAttributedString.Key: Any] {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineSpacing = lineSpacing
+        return [
+            .font: font,
+            .foregroundColor: textColor,
+            .paragraphStyle: paragraph
+        ]
+    }
+
+    // MARK: - Coordinator
+
+    final class Coordinator: NSObject, UITextViewDelegate {
+
+        private var parent: GrowingTextEditor
+
+        init(_ parent: GrowingTextEditor) {
+            self.parent = parent
+        }
+
+        // 사용자 입력 -> 외부 text 바인딩 갱신
+        func textViewDidChange(_ textView: UITextView) {
+            parent.text = textView.text
+        }
+
+        // first responder 진입/해제 -> 외부 isFocused 바인딩 갱신
+        func textViewDidBeginEditing(_ textView: UITextView) {
+            parent.isFocused = true
+        }
+
+        func textViewDidEndEditing(_ textView: UITextView) {
+            parent.isFocused = false
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("빈 상태 & 자유 입력") {
+    struct PreviewWrapper: View {
+        @State private var text: String = ""
+        @State private var isFocused: Bool = false
+
+        var body: some View {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("focus: \(isFocused ? "true" : "false")")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    GrowingTextEditor(text: $text, isFocused: $isFocused)
+                        .padding(20)
+                        .background(Color(.systemGray6))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+
+                    Button(isFocused ? "키보드 내리기" : "키보드 올리기") {
+                        isFocused.toggle()
+                    }
+                }
+                .padding(20)
+            }
+        }
+    }
+    return PreviewWrapper()
+}
+
+#Preview("긴 텍스트 - 외곽 스크롤 동작") {
+    struct PreviewWrapper: View {
+        @State private var text: String = String(repeating: "동적 높이 텍스트뷰 동작 확인 줄입니다.\n", count: 30)
+        @State private var isFocused: Bool = false
+
+        var body: some View {
+            ScrollView {
+                GrowingTextEditor(text: $text, isFocused: $isFocused)
+                    .padding(20)
+            }
+        }
+    }
+    return PreviewWrapper()
+}

--- a/VibeTrip/Views/Components/GrowingTextEditor.swift
+++ b/VibeTrip/Views/Components/GrowingTextEditor.swift
@@ -83,6 +83,13 @@ struct GrowingTextEditor: UIViewRepresentable {
         }
     }
 
+    // 화면 너비에 맞춰 자동 줄바꿈 동작 보장
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: UITextView, context: Context) -> CGSize? {
+        guard let width = proposal.width, width.isFinite, width > 0 else { return nil }
+        let fitting = uiView.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
+        return CGSize(width: width, height: fitting.height)
+    }
+
     // MARK: - Helpers
 
     // 폰트/줄간격/색상을 묶은 공통 속성 생성


### PR DESCRIPTION
## 📄 작업 내용
- 로그 작성 화면의 텍스트 입력 영역을 동적 높이 입력 컴포넌트로 교체
- 로그 저장 직후 목록 반영 누락 및 이미지 지연 표시 문제 개선
- 로그 수정 시 기존 사진 삭제 대상이 어긋나던 문제 수정
- 저장 중 중복 요청 및 입력 변경 방지 처리 추가

## 🔗 관련 이슈
<!-- ex) close #12 -->
close #132 

## ✅ 체크리스트
- [ ] 텍스트 정상 입력
- [ ] 로그 저장 직후 로그 목록에 사진 정상 표시
- [ ] 로그 저장 중 입력 방지
