### PR TITLE
fix(#137): 음악 생성 완료 후 메인페이지에 해당 카드 누락되는 문제

### DIFF
--- a/VibeTrip/Features/Album/ViewModels/MainPageViewModel.swift
+++ b/VibeTrip/Features/Album/ViewModels/MainPageViewModel.swift
@@ -196,7 +196,7 @@ final class MainPageViewModel: ObservableObject {
         }
         if let detail = try? await albumService.fetchAlbum(albumId: albumId),
            detail.musicUrl != nil {
-            applyAlbumReady(detail: detail, for: albumId)
+            await finalizeCompletion(detail: detail, for: albumId)
             return
         }
         // 단건 확인 실패: 반복 폴링으로 폴백
@@ -214,7 +214,7 @@ final class MainPageViewModel: ObservableObject {
         pollingTasks[albumId] = nil
         if let detail = try? await albumService.fetchAlbum(albumId: albumId),
            detail.musicUrl != nil {
-            applyAlbumReady(detail: detail, for: albumId)
+            await finalizeCompletion(detail: detail, for: albumId)
             return
         }
         // 단건 확인 실패: 반복 폴링으로 폴백
@@ -232,10 +232,22 @@ final class MainPageViewModel: ObservableObject {
             guard !Task.isCancelled else { return }
             guard let detail = try? await albumService.fetchAlbum(albumId: albumId),
                   detail.musicUrl != nil else { continue }
-            applyAlbumReady(detail: detail, for: albumId)
+            await finalizeCompletion(detail: detail, for: albumId)
             return
         }
         pollingTasks[albumId] = nil
+    }
+
+    // FCM·폴링·1회 확인 세 경로의 완료 처리를 모으는 단일 진입점
+    private func finalizeCompletion(detail: AlbumDetail, for albumId: Int) async {
+        applyAlbumReady(detail: detail, for: albumId)
+
+        // 목록에 없는 신규 완료 앨범(서버 반영 지연 등)은 카드가 생기지 않으므로 서버 목록을 1회 재조회
+        // refreshAlbumsWithoutClearing 내부의 cancelAllPolling이 현재 폴링 Task를 취소하지 않도록 별도 Task로 실행
+        guard !albums.contains(where: { $0.id == albumId }) else { return }
+        Task { [weak self] in
+            await self?.refreshAlbumsWithoutClearing()
+        }
     }
 
     // 음악 생성 완료 시: title 업데이트 + readyAlbumIds 등록 + 폴링 Task 정리

--- a/VibeTripTests/MainPageViewModelTests.swift
+++ b/VibeTripTests/MainPageViewModelTests.swift
@@ -59,13 +59,16 @@ private final class PollingStubAlbumService: AlbumServiceProtocol {
     // 앨범별 폴링 완료 타이틀 오버라이드(없으면 기존 카드 타이틀 유지)
     var resolvedTitleByAlbumId: [Int: String] = [:]
     private(set) var titleFetchCounts: [Int: Int] = [:]
+    // fetchAlbums(목록) 호출 횟수
+    private(set) var listFetchCount: Int = 0
 
     init(albums: [AlbumCard]) {
         self.albums = albums
     }
 
     func fetchAlbums(cursor: Int?, limit: Int) async throws -> AlbumListPayload {
-        AlbumListPayload(content: albums, totalCount: albums.count, hasNext: false)
+        listFetchCount += 1
+        return AlbumListPayload(content: albums, totalCount: albums.count, hasNext: false)
     }
 
     func fetchAlbum(albumId: Int) async throws -> AlbumDetail {
@@ -402,19 +405,42 @@ final class MainPageViewModelTests: XCTestCase {
         XCTAssertNotNil(stub.titleFetchCounts[1])
     }
 
-    // albums에 없는 albumId -> 크래시 없이 종료, 기존 albums 변경 없음
-    func test_handleAlbumCompleted_notInAlbums_noEffect() async {
-        let album = AlbumCard(id: 1, title: "기존 타이틀", location: "서울", startDate: "2026-01-01", endDate: "2026-01-02", coverImageUrl: nil)
+    // albums에 없는 albumId 완료(서버 목록 반영 지연) -> 목록 재조회로 신규 카드 노출
+    func test_handleAlbumCompleted_notInAlbums_triggersListRefresh() async {
+        let existing = AlbumCard(id: 1, title: "기존 타이틀", location: "서울", startDate: "2026-01-01", endDate: "2026-01-02", coverImageUrl: nil)
+        let stub = PollingStubAlbumService(albums: [existing])
+        stub.titleReadyAfterAttempts = 1
+        sut = MainPageViewModel(albumService: stub, pollingInterval: 0,
+                                notificationAuthorizationChecker: { .authorized })
+
+        await sut.loadAlbums()                          // albums = [1]
+
+        // 서버가 신규 앨범을 뒤늦게 목록에 반영한 상황 시뮬레이션
+        let newAlbum = AlbumCard(id: 999, title: "새 앨범", location: "부산", startDate: "2026-02-01", endDate: "2026-02-02", coverImageUrl: nil)
+        stub.albums = [existing, newAlbum]
+
+        await sut.handleAlbumCompleted(albumId: 999)    // 목록에 없는 완료 신호
+        try? await Task.sleep(nanoseconds: 20_000_000)  // 폴백 재조회 Task 완료 대기
+
+        XCTAssertTrue(sut.albums.contains(where: { $0.id == 999 }))  // 신규 카드 추가됨
+        XCTAssertTrue(sut.isReady(for: 999))
+    }
+
+    // albums에 있는 albumId 완료 -> 추가 목록 재조회 없음(회귀 방지)
+    func test_handleAlbumCompleted_inAlbums_noListRefetch() async {
+        let album = AlbumCard(id: 1, title: nil, location: "서울", startDate: "2026-01-01", endDate: "2026-01-02", coverImageUrl: nil)
         let stub = PollingStubAlbumService(albums: [album])
         stub.titleReadyAfterAttempts = 1
         sut = MainPageViewModel(albumService: stub, pollingInterval: 0,
                                 notificationAuthorizationChecker: { .authorized })
 
         await sut.loadAlbums()
-        await sut.handleAlbumCompleted(albumId: 999)    // 존재하지 않는 albumId
+        let baseline = stub.listFetchCount
 
-        XCTAssertEqual(sut.albums.count, 1)
-        XCTAssertEqual(sut.albums.first?.title, "기존 타이틀")  // 변경 없음
+        await sut.handleAlbumCompleted(albumId: 1)      // 이미 목록에 있는 albumId
+        try? await Task.sleep(nanoseconds: 20_000_000)
+
+        XCTAssertEqual(stub.listFetchCount, baseline)   // 폴백 재조회 미발생
     }
 
     // MARK: - startPollingIfNeeded 권한 분기


### PR DESCRIPTION
## 📄 작업 내용
<!-- 변경한 내용을 간략히 설명해주세요 -->

## 🔗 관련 이슈
Closes #137 

## ✅ 체크리스트
- [ ] 생성 완료 후 메인페이지에 해당 앨범 카드 정상 표시
