### PR TITLE
fix(#138): 로그 텍스트 더 보기 버튼 미표시 및 최상단 버튼 겹침 오류

### DIFF
--- a/VibeTrip/Features/Album/Views/AlbumDetailView.swift
+++ b/VibeTrip/Features/Album/Views/AlbumDetailView.swift
@@ -1722,11 +1722,11 @@ private struct AlbumDetailLogTextSection: View {
     private enum Constants {
         static let fontSize: CGFloat = 16
         static let lineLimit: Int = 2
-        static let widthBuffer: CGFloat = 1
-        static let truncationToken: String = "..."
         static let moreButtonText: String = "더 보기"
         static let foldButtonText: String = "접기"
         static let foldSpacer: String = "  "    /// 접기 버튼과 본문 텍스트 사이 공간 예약용
+        static let reservedGap: CGFloat = 8     // "더 보기" 버튼과 본문 사이 간격
+        static let animationDuration: CGFloat = 0.2
     }
     
     private var textFont: Font { .setPretendard(weight: .regular, size: Constants.fontSize) }
@@ -1737,71 +1737,29 @@ private struct AlbumDetailLogTextSection: View {
         ?? UIFont.systemFont(ofSize: Constants.fontSize)
     }
     
-    // NSLayoutManager 기반 줄 수 측정 (접힌 상태 prefix 이진 탐색용)
-    private func lineCount(_ value: String, width: CGFloat) -> Int {
-        guard width > 0, !value.isEmpty else { return 0 }
-        
-        let storage = NSTextStorage(
-            string: value,
-            attributes: [.font: uiFont]
-        )
-        let container = NSTextContainer(size: CGSize(width: width, height: .greatestFiniteMagnitude))
-        container.lineFragmentPadding = 0
-        container.lineBreakMode = .byWordWrapping
-        container.maximumNumberOfLines = 0
-        
-        let manager = NSLayoutManager()
-        manager.addTextContainer(container)
-        storage.addLayoutManager(manager)
-        _ = manager.glyphRange(for: container)
-        
-        var count = 0
-        manager.enumerateLineFragments(
-            forGlyphRange: NSRange(location: 0, length: manager.numberOfGlyphs)
-        ) { _, _, _, _, _ in
-            count += 1
-        }
-        return count
+    private var textUIColor: UIColor { UIColor(named: "text") ?? .label }
+
+    // "더 보기" 버튼 폭 + 간격 = 마지막 줄 우측에 비워둘 예약 폭
+    private var reservedTextWidth: CGFloat {
+        (Constants.moreButtonText as NSString)
+            .size(withAttributes: [.font: uiFont]).width
     }
-    
-    // 접힌 상태: 이진 탐색 계산으로 ... 더 보기 표시
-    // 원문이 2줄 이내일 경우 nil 반환 -> truncation 불필요
-    private func collapsedPrefix(for width: CGFloat) -> String? {
-        guard width > 0 else { return nil }
-        
-        let measureWidth = max(0, width - Constants.widthBuffer)
-        guard measureWidth > 0 else { return nil }
-        
-        if lineCount(text, width: measureWidth) <= Constants.lineLimit { return nil }
-        
-        let tail = Constants.truncationToken + Constants.moreButtonText
-        
-        func fits(_ candidate: String) -> Bool {
-            lineCount(candidate + tail, width: measureWidth) <= Constants.lineLimit
-        }
-        
-        let chars = Array(text)
-        var lo = 0, hi = chars.count
-        while lo < hi {
-            let mid = (lo + hi + 1) / 2
-            if fits(String(chars.prefix(mid))) { lo = mid } else { hi = mid - 1 }
-        }
-        return String(chars.prefix(lo))
-    }
+    private var reservedTailWidth: CGFloat { reservedTextWidth + Constants.reservedGap }
     
     var body: some View {
-        let cutPrefix = collapsedPrefix(for: contentWidth)
-        
+        let truncation = LogTextTruncationAnalyzer.analyze(
+            text: text,
+            font: uiFont,
+            width: contentWidth,
+            reservedTailWidth: reservedTailWidth,
+            lineLimit: Constants.lineLimit
+        )
+
         Group {
             if isExpanded {
                 expandedContent
-            } else if let cutPrefix {
-                collapsedContent(cutPrefix: cutPrefix)
             } else {
-                Text(text)
-                    .font(textFont)
-                    .foregroundStyle(Color.text)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                collapsedContent(truncation: truncation)
             }
         }
         // 콘텐츠 너비 측정
@@ -1826,7 +1784,7 @@ private struct AlbumDetailLogTextSection: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .overlay(alignment: .bottomTrailing) {  /// 접기 버튼 배치
             Button(Constants.foldButtonText) {
-                withAnimation(.easeInOut(duration: 0.2)) { isExpanded = false }
+                withAnimation(.easeInOut(duration: Constants.animationDuration)) { isExpanded = false }
             }
             .font(textFont)
             .foregroundStyle(actionColor)
@@ -1834,22 +1792,33 @@ private struct AlbumDetailLogTextSection: View {
         }
     }
     
-    // 접힌 상태:  cut + "..." + "더 보기" 를 Text concat 으로 한 줄로 이어 렌더
-    // prefix 이진 탐색: 2줄에 맞게 잘라줌
-    private func collapsedContent(cutPrefix: String) -> some View {
-        (
-            Text(cutPrefix + Constants.truncationToken)
-            + Text(Constants.moreButtonText)
-                .foregroundColor(actionColor)
-        )
-        .font(textFont)
-        .foregroundStyle(Color.text)
-        .lineLimit(Constants.lineLimit)
-        .fixedSize(horizontal: false, vertical: true)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .contentShape(Rectangle())
-        .onTapGesture {
-            withAnimation(.easeInOut(duration: 0.2)) { isExpanded = true }
+    // 접힌 상태: 2줄로 접고, 잘릴 때만 우측에 "더 보기" 버튼 표시
+    private func collapsedContent(truncation: LogTextTruncationAnalyzer.Result) -> some View {
+        ZStack(alignment: .bottomTrailing) {
+            CollapsibleLogTextView(
+                text: text,
+                font: uiFont,
+                textColor: textUIColor,
+                lineLimit: Constants.lineLimit,
+                reservedTailWidth: truncation.isTruncated ? reservedTailWidth : 0,
+                showsEllipsis: truncation.isTruncated && !truncation.lastVisibleLineEndsWithNewline
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                guard truncation.isTruncated else { return }
+                withAnimation(.easeInOut(duration: Constants.animationDuration)) { isExpanded = true }
+            }
+
+            if truncation.isTruncated {
+                Button(Constants.moreButtonText) {
+                    withAnimation(.easeInOut(duration: Constants.animationDuration)) { isExpanded = true }
+                }
+                .font(textFont)
+                .foregroundStyle(actionColor)
+                .buttonStyle(.plain)
+                .frame(width: reservedTextWidth, alignment: .trailing)
+            }
         }
     }
 }

--- a/VibeTrip/Features/Album/Views/AlbumDetailView.swift
+++ b/VibeTrip/Features/Album/Views/AlbumDetailView.swift
@@ -1720,6 +1720,7 @@ private struct AlbumDetailLogTextSection: View {
     @State private var contentWidth: CGFloat = 0
     
     private enum Constants {
+        static let fontName: String = "Pretendard-Regular"
         static let fontSize: CGFloat = 16
         static let lineLimit: Int = 2
         static let moreButtonText: String = "더 보기"
@@ -1728,12 +1729,13 @@ private struct AlbumDetailLogTextSection: View {
         static let reservedGap: CGFloat = 8     // "더 보기" 버튼과 본문 사이 간격
         static let animationDuration: CGFloat = 0.2
     }
-    
-    private var textFont: Font { .setPretendard(weight: .regular, size: Constants.fontSize) }
+
+    // 접힌 본문(UITextView)과 동일하게 Dynamic Type 비스케일 고정 크기 사용
+    private var textFont: Font { .custom(Constants.fontName, fixedSize: Constants.fontSize) }
     private let actionColor = Color("GrayScale/400")
-    
+
     private var uiFont: UIFont {
-        UIFont(name: "Pretendard-Regular", size: Constants.fontSize)
+        UIFont(name: Constants.fontName, size: Constants.fontSize)
         ?? UIFont.systemFont(ofSize: Constants.fontSize)
     }
     

--- a/VibeTrip/Features/Album/Views/AlbumDetailView.swift
+++ b/VibeTrip/Features/Album/Views/AlbumDetailView.swift
@@ -1772,19 +1772,21 @@ private struct AlbumDetailLogTextSection: View {
         }
     }
     
-    // 펼친 상태: SwiftUI 레이아웃에 공간 예약을 맡겨 접기 버튼 배치
+    // 펼친 상태: 접힘과 같은 UITextView 엔진으로 전체 표시 (편집 페이지와 줄바꿈 일치)
+    // 마지막 줄 끝에 투명 "접기" 예약 텍스트로 공간을 비우고 그 위에 접기 버튼 배치
     private var expandedContent: some View {
-        (
-            Text(text)
-            + Text(Constants.foldSpacer + Constants.foldButtonText)
-                .foregroundColor(.clear)
-        )
-        .font(textFont)
-        .foregroundStyle(Color.text)
-        .lineLimit(nil)
-        .fixedSize(horizontal: false, vertical: true)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .overlay(alignment: .bottomTrailing) {  /// 접기 버튼 배치
+        ZStack(alignment: .bottomTrailing) {
+            CollapsibleLogTextView(
+                text: text,
+                font: uiFont,
+                textColor: textUIColor,
+                lineLimit: 0,
+                reservedTailWidth: 0,
+                showsEllipsis: false,
+                trailingReserveText: Constants.foldSpacer + Constants.foldButtonText
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+
             Button(Constants.foldButtonText) {
                 withAnimation(.easeInOut(duration: Constants.animationDuration)) { isExpanded = false }
             }

--- a/VibeTrip/Features/Album/Views/AlbumDetailView.swift
+++ b/VibeTrip/Features/Album/Views/AlbumDetailView.swift
@@ -409,8 +409,14 @@ struct AlbumDetailView: View {
                         
                         coverImageSection
                         actionButtonsSection
-                        contentSection
+                        contentSection(proxy: proxy)
                     }
+                    // 카드의 콘텐츠 기준 위치 측정용 좌표계 -> 가림 판단
+                    .coordinateSpace(.named(albumDetailScrollSpace))
+                }
+                // 플로팅 버튼 영역만큼 하단을 비워 콘텐츠가 버튼 위에 위치
+                .safeAreaInset(edge: .bottom, spacing: 0) {
+                    Color.clear.frame(height: Constants.floatingButtonSafeInset)
                 }
                 .scrollDisabled(logViewModel.logs.isEmpty)
                 .ignoresSafeArea(edges: .top)
@@ -937,9 +943,25 @@ private extension AlbumDetailView {
     
     // ViewModel 상태에 따라 빈 상태 / 로딩 / 로그 피드 표시
     @ViewBuilder
-    var contentSection: some View {
+    func contentSection(proxy: ScrollViewProxy) -> some View {
         if !logViewModel.logs.isEmpty {
-            AlbumDetailLogFeedSection(viewModel: logViewModel, onEdit: { logPresentation = .edit($0) })
+            AlbumDetailLogFeedSection(
+                viewModel: logViewModel,
+                onEdit: { logPresentation = .edit($0) },
+                onRevealCard: { cardId, cardContentMaxY in
+                    // 플로팅 버튼이 표시 중일 때만
+                    guard showScrollToTop else { return }
+                    // 접기 버튼이 플로팅 버튼 영역에 들어올 때만 스크롤
+                    if let scrollView = observedScrollView {
+                        let onScreenBottom = cardContentMaxY - scrollView.contentOffset.y
+                        let safeBottom = scrollView.bounds.height - Constants.floatingButtonSafeInset
+                        guard onScreenBottom > safeBottom else { return }
+                    }
+                    withAnimation(.easeInOut(duration: Constants.scrollToTopAnimationDuration)) {
+                        proxy.scrollTo(cardId, anchor: .bottom)
+                    }
+                }
+            )
         } else if logViewModel.isLoading {
             ProgressView()
                 .frame(maxWidth: .infinity)
@@ -966,7 +988,7 @@ private extension AlbumDetailView {
             proxy.scrollTo("scrollTop", anchor: .top)
         }
     }
-    
+
     func scrollToTopButton(action: @escaping () -> Void) -> some View {
         Button(action: action) {
             HStack(alignment: .center, spacing: 0) {
@@ -1111,6 +1133,8 @@ private extension AlbumDetailView {
         static let scrollToTopTrailingPadding: CGFloat = 20
         static let scrollToTopBottomPadding: CGFloat = 40
         static let scrollToTopAnimationDuration: Double = 0.2
+        // 플로팅 버튼이 차지하는 화면 하단 영역
+        static let floatingButtonSafeInset: CGFloat = scrollToTopBottomPadding + scrollToTopButtonSize + 16
     }
 }
 
@@ -1426,17 +1450,24 @@ private struct AlbumDetailLogMenuPopup: View {
     }
 }
 
+// 가림 판단용: 콘텐츠 좌표계 이름 + 카드 하단 위치 보관
+private let albumDetailScrollSpace = "albumDetailScroll"
+
+private final class CardBottomTracker {
+    var contentMaxY: CGFloat = 0   // 카드 하단의 콘텐츠 좌표계 기준 y
+}
+
 // MARK: - AlbumDetailLogFeedSection
 
 private struct AlbumDetailLogFeedSection: View {
-    
+
     @ObservedObject var viewModel: AlbumDetailViewModel
     let onEdit: (AlbumLogEntry) -> Void
+    let onRevealCard: (Int, CGFloat) -> Void // (카드 id, 카드 하단 콘텐츠 y) — 가릴 때만 스크롤
     
     private enum Constants {
         static let horizontalPadding: CGFloat = 20
         static let topPadding: CGFloat = 4
-        static let bottomPadding: CGFloat = 40
     }
     
     var body: some View {
@@ -1457,13 +1488,13 @@ private struct AlbumDetailLogFeedSection: View {
                         viewModel.requestDeleteLog(id: logId)
                     },
                     onEdit: onEdit,
-                    awaitingImageLogIds: viewModel.awaitingImageLogIds
+                    awaitingImageLogIds: viewModel.awaitingImageLogIds,
+                    onRevealCard: onRevealCard
                 )
             }
         }
         .padding(.horizontal, Constants.horizontalPadding)
         .padding(.top, Constants.topPadding)
-        .padding(.bottom, Constants.bottomPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
@@ -1479,6 +1510,7 @@ private struct AlbumDetailLogDateGroup: View {
     let onDeleteLog: (Int) -> Void
     let onEdit: (AlbumLogEntry) -> Void
     let awaitingImageLogIds: Set<Int>
+    let onRevealCard: (Int, CGFloat) -> Void
 
     private enum Constants {
         /// 로그 카드 간 간격
@@ -1494,8 +1526,10 @@ private struct AlbumDetailLogDateGroup: View {
                     onLastAppear: onLastAppear,
                     onDeleteLog: onDeleteLog,
                     onEdit: onEdit,
-                    showSkeletonIfNoImages: awaitingImageLogIds.contains(entry.id)
+                    showSkeletonIfNoImages: awaitingImageLogIds.contains(entry.id),
+                    onRevealCard: onRevealCard
                 )
+                .id(entry.id)   // 펼침 시 이 카드로 scrollTo 하기 위한 앵커
             }
         }
     }
@@ -1512,10 +1546,13 @@ private struct AlbumDetailLogItemCard: View {
     let onEdit: (AlbumLogEntry) -> Void
     // 방금 저장한 로그처럼 이미지 응답이 비어 있을 때 슬라이더 자리에 스켈레톤을 그릴지 여부
     let showSkeletonIfNoImages: Bool
-    
-    /// 로그 옵션 팝업 표시 여부
+    let onRevealCard: (Int, CGFloat) -> Void
+
+    // 로그 옵션 팝업 표시 여부
     @State private var isMenuVisible: Bool = false
-    
+    // 카드 하단의 콘텐츠 좌표계 기준 y (가림 판단용)
+    @State private var bottomTracker = CardBottomTracker()
+
     private enum Constants {
         static let dateFontSize: CGFloat = 14
         static let menuIconSize: CGFloat = 16
@@ -1526,6 +1563,8 @@ private struct AlbumDetailLogItemCard: View {
         static let menuTopOffset: CGFloat = 26
         static let menuTrailingPadding: CGFloat = 17
         static let labelColor = Color(red: 0.74, green: 0.75, blue: 0.76)
+        // 펼침 애니메이션이 끝나 카드 높이가 확정된 뒤 스크롤하도록 약간 지연
+        static let expandScrollDelay: Double = 0.3
     }
     
     /// postedAt ISO8601 → "yyyy년 M월 d일" 포맷
@@ -1575,8 +1614,13 @@ private struct AlbumDetailLogItemCard: View {
                 }
                 
                 // 텍스트 + 더보기/접기
-                AlbumDetailLogTextSection(text: entry.description)
-                    .padding(.top, Constants.contentSpacing)
+                AlbumDetailLogTextSection(text: entry.description, onExpand: {
+                    // 펼침 레이아웃이 잡힌 뒤, 카드 하단 위치와 함께 자동 스크롤 요청
+                    DispatchQueue.main.asyncAfter(deadline: .now() + Constants.expandScrollDelay) {
+                        onRevealCard(entry.id, bottomTracker.contentMaxY)
+                    }
+                })
+                .padding(.top, Constants.contentSpacing)
             }
             
             // 팝업 표시 시: 외부 탭 dismiss 영역 + 팝업
@@ -1606,6 +1650,12 @@ private struct AlbumDetailLogItemCard: View {
                 .padding(.top, Constants.menuTopOffset)
                 .padding(.trailing, Constants.menuTrailingPadding)
             }
+        }
+        // 카드 하단의 콘텐츠 기준 y 추적 (가림 판단용)
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.frame(in: .named(albumDetailScrollSpace)).maxY
+        } action: { newValue in
+            bottomTracker.contentMaxY = newValue
         }
         .onAppear {
             guard isLast else { return }
@@ -1714,7 +1764,9 @@ private struct AlbumDetailLogImageSkeleton: View {
 
 private struct AlbumDetailLogTextSection: View {
     let text: String
-    
+    /// 더보기로 펼쳐질 때 호출 
+    var onExpand: (() -> Void)? = nil
+
     @State private var isExpanded: Bool = false
     /// GeometryReader로 측정한 실제 콘텐츠 너비
     @State private var contentWidth: CGFloat = 0
@@ -1801,6 +1853,11 @@ private struct AlbumDetailLogTextSection: View {
         }
     }
     
+    private func expand() {
+        withAnimation(.easeInOut(duration: Constants.animationDuration)) { isExpanded = true }
+        onExpand?()
+    }
+
     // 접힌 상태: 2줄로 접고, 잘릴 때만 우측에 "더 보기" 버튼 표시
     private func collapsedContent(truncation: LogTextTruncationAnalyzer.Result) -> some View {
         ZStack(alignment: .bottomTrailing) {
@@ -1816,12 +1873,12 @@ private struct AlbumDetailLogTextSection: View {
             .contentShape(Rectangle())
             .onTapGesture {
                 guard truncation.isTruncated else { return }
-                withAnimation(.easeInOut(duration: Constants.animationDuration)) { isExpanded = true }
+                expand()
             }
 
             if truncation.isTruncated {
                 Button(Constants.moreButtonText) {
-                    withAnimation(.easeInOut(duration: Constants.animationDuration)) { isExpanded = true }
+                    expand()
                 }
                 .font(textFont)
                 .foregroundStyle(actionColor)

--- a/VibeTrip/Features/Album/Views/AlbumDetailView.swift
+++ b/VibeTrip/Features/Album/Views/AlbumDetailView.swift
@@ -1726,7 +1726,8 @@ private struct AlbumDetailLogTextSection: View {
         static let moreButtonText: String = "더 보기"
         static let foldButtonText: String = "접기"
         static let foldSpacer: String = "  "    /// 접기 버튼과 본문 텍스트 사이 공간 예약용
-        static let reservedGap: CGFloat = 8     // "더 보기" 버튼과 본문 사이 간격
+        static let reservedGap: CGFloat = 8         // "더 보기"/"접기" 버튼과 본문 사이 간격
+        static let buttonTrailingInset: CGFloat = 8 // 버튼과 우측 끝 사이 간격
         static let animationDuration: CGFloat = 0.2
     }
 
@@ -1746,7 +1747,10 @@ private struct AlbumDetailLogTextSection: View {
         (Constants.moreButtonText as NSString)
             .size(withAttributes: [.font: uiFont]).width
     }
-    private var reservedTailWidth: CGFloat { reservedTextWidth + Constants.reservedGap }
+    // 마지막 줄 우측 공간
+    private var reservedTailWidth: CGFloat {
+        reservedTextWidth + Constants.reservedGap + Constants.buttonTrailingInset
+    }
     
     var body: some View {
         let truncation = LogTextTruncationAnalyzer.analyze(
@@ -1793,6 +1797,7 @@ private struct AlbumDetailLogTextSection: View {
             .font(textFont)
             .foregroundStyle(actionColor)
             .buttonStyle(.plain)
+            .padding(.trailing, Constants.buttonTrailingInset)
         }
     }
     
@@ -1822,6 +1827,7 @@ private struct AlbumDetailLogTextSection: View {
                 .foregroundStyle(actionColor)
                 .buttonStyle(.plain)
                 .frame(width: reservedTextWidth, alignment: .trailing)
+                .padding(.trailing, Constants.buttonTrailingInset)
             }
         }
     }

--- a/VibeTrip/Shared/Components/Representables/CollapsibleLogTextView.swift
+++ b/VibeTrip/Shared/Components/Representables/CollapsibleLogTextView.swift
@@ -1,0 +1,244 @@
+//
+//  CollapsibleLogTextView.swift
+//  VibeTrip
+//
+//  Created by CHOI on 6/5/26.
+//
+
+import SwiftUI
+import UIKit
+
+// MARK: - LogTextTruncationAnalyzer
+
+
+// 측정과 실제 렌더링을 같은 TextKit 엔진으로 통일하기 위한 함수
+enum LogTextTruncationAnalyzer {
+
+    struct Result: Equatable {
+        let isTruncated: Bool   // 본문이 lineLimit 줄을 초과해 가려진 내용이 있는지
+        let lastVisibleLineEndsWithNewline: Bool // 표시되는 마지막 줄이 하드 줄바꿈(`\n`)으로 끝나는지 (true면 말줄임 생략)
+
+        static let none = Result(isTruncated: false, lastVisibleLineEndsWithNewline: false)
+    }
+
+    static func analyze(
+        text: String,
+        font: UIFont,
+        width: CGFloat,
+        reservedTailWidth: CGFloat, // 마지막 줄 우측에 비워둘 버튼 예약 폭
+        lineLimit: Int              // 접힌 상태에서 보여줄 최대 줄 수
+    ) -> Result {
+        guard width > 0, lineLimit > 0, !text.isEmpty else { return .none }
+
+        // 1. 전체 너비 기준으로 실제 줄 수가 limit을 넘는지 -> 버튼 표시 여부
+        guard lineCount(text: text, font: font, width: width, exclusion: nil) > lineLimit else {
+            return .none
+        }
+
+        // 2. 예약 영역을 반영한 레이아웃에서 마지막 표시 줄이 줄바꿈으로 끝나는지 판정
+        let endsWithNewline = lastVisibleLineEndsWithNewline(
+            text: text,
+            font: font,
+            width: width,
+            reservedTailWidth: reservedTailWidth,
+            lineLimit: lineLimit
+        )
+        return Result(isTruncated: true, lastVisibleLineEndsWithNewline: endsWithNewline)
+    }
+
+    // MARK: Layout helpers
+
+    private static func makeLayoutManager(
+        text: String,
+        font: UIFont,
+        width: CGFloat,
+        exclusion: CGRect?
+    ) -> (manager: NSLayoutManager, storage: NSTextStorage) {
+        let storage = NSTextStorage(string: text, attributes: [.font: font])
+        let container = NSTextContainer(
+            size: CGSize(width: width, height: .greatestFiniteMagnitude)
+        )
+        container.lineFragmentPadding = 0
+        container.lineBreakMode = .byWordWrapping
+        container.maximumNumberOfLines = 0
+        if let exclusion {
+            container.exclusionPaths = [UIBezierPath(rect: exclusion)]
+        }
+
+        let manager = NSLayoutManager()
+        manager.addTextContainer(container)
+        storage.addLayoutManager(manager)
+        manager.ensureLayout(for: container)
+        return (manager, storage)
+    }
+
+    private static func lineCount(
+        text: String,
+        font: UIFont,
+        width: CGFloat,
+        exclusion: CGRect?
+    ) -> Int {
+        let (manager, _) = makeLayoutManager(text: text, font: font, width: width, exclusion: exclusion)
+        var count = 0
+        manager.enumerateLineFragments(
+            forGlyphRange: NSRange(location: 0, length: manager.numberOfGlyphs)
+        ) { _, _, _, _, _ in
+            count += 1
+        }
+        return count
+    }
+
+    // lineLimit번째 줄의 문자 범위 마지막 글자가 개행인지 검사
+    private static func lastVisibleLineEndsWithNewline(
+        text: String,
+        font: UIFont,
+        width: CGFloat,
+        reservedTailWidth: CGFloat,
+        lineLimit: Int
+    ) -> Bool {
+        let lineHeight = font.lineHeight
+        let exclusion: CGRect? = reservedTailWidth > 0
+            ? CGRect(
+                x: max(0, width - reservedTailWidth),
+                y: lineHeight * CGFloat(lineLimit - 1),
+                width: reservedTailWidth,
+                height: lineHeight
+            )
+            : nil
+
+        let (manager, storage) = makeLayoutManager(
+            text: text, font: font, width: width, exclusion: exclusion
+        )
+
+        var currentLine = 0
+        var targetGlyphRange: NSRange?
+        manager.enumerateLineFragments(
+            forGlyphRange: NSRange(location: 0, length: manager.numberOfGlyphs)
+        ) { _, _, _, glyphRange, stop in
+            currentLine += 1
+            if currentLine == lineLimit {
+                targetGlyphRange = glyphRange
+                stop.pointee = true
+            }
+        }
+
+        guard let targetGlyphRange else { return false }
+        let charRange = manager.characterRange(forGlyphRange: targetGlyphRange, actualGlyphRange: nil)
+        guard charRange.length > 0 else { return false }
+
+        let lastIndex = charRange.location + charRange.length - 1
+        let lastChar = (storage.string as NSString).substring(with: NSRange(location: lastIndex, length: 1))
+        return lastChar == "\n"
+    }
+}
+
+// MARK: - CollapsibleLogTextView
+
+// 읽기 전용 본문을 지정한 줄 수로 접어 보여주는 컴포넌트
+struct CollapsibleLogTextView: UIViewRepresentable {
+
+    // MARK: Inputs
+
+    let text: String
+    let font: UIFont
+    let textColor: UIColor
+    let lineLimit: Int
+    let reservedTailWidth: CGFloat // 마지막 줄 우측에 비워둘 버튼 예약 폭 (0이면 예약/절단 없음)
+    let showsEllipsis: Bool        // 예약 영역에 닿아 잘릴 때 말줄임(…)을 붙일지
+
+    // MARK: - UIViewRepresentable
+
+    func makeUIView(context: Context) -> UITextView {
+        let textView = UITextView()
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        // 탭은 SwiftUI 측 제스처가 처리하도록 UIKit 상호작용 차단
+        textView.isUserInteractionEnabled = false
+        textView.contentInsetAdjustmentBehavior = .never
+        textView.contentInset = .zero
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.adjustsFontForContentSizeCategory = false
+        textView.backgroundColor = .clear
+        textView.setContentCompressionResistancePriority(.required, for: .vertical)
+        return textView
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        // 기본 속성만 갱신 -> 너비 의존적인 예약/줄바꿈 설정은 sizeThatFits에서 처리
+        if uiView.text != text { uiView.text = text }
+        uiView.font = font
+        uiView.textColor = textColor
+        uiView.textContainer.maximumNumberOfLines = lineLimit
+    }
+
+    // 최종 너비를 알 수 있는 시점에 예약 영역/줄바꿈 모드를 확정하고 높이를 계산
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: UITextView, context: Context) -> CGSize? {
+        guard let width = proposal.width, width.isFinite, width > 0 else { return nil }
+        configure(uiView, width: width)
+        let fitting = uiView.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
+        return CGSize(width: width, height: fitting.height)
+    }
+
+    // MARK: - Helpers
+
+    private func configure(_ textView: UITextView, width: CGFloat) {
+        if textView.text != text { textView.text = text }
+        textView.font = font
+        textView.textColor = textColor
+        textView.textContainer.maximumNumberOfLines = lineLimit
+
+        guard reservedTailWidth > 0 else {
+            textView.textContainer.exclusionPaths = []
+            textView.textContainer.lineBreakMode = .byWordWrapping
+            return
+        }
+
+        let lineHeight = font.lineHeight
+        let reservedRect = CGRect(
+            x: max(0, width - reservedTailWidth),
+            y: lineHeight * CGFloat(lineLimit - 1),
+            width: reservedTailWidth,
+            height: lineHeight
+        )
+        textView.textContainer.exclusionPaths = [UIBezierPath(rect: reservedRect)]
+        // 예약 영역에 닿아 잘릴 때만 말줄임, 줄바꿈으로 끝난 경우는 그냥 클립
+        textView.textContainer.lineBreakMode = showsEllipsis ? .byTruncatingTail : .byWordWrapping
+    }
+}
+
+// MARK: - Preview
+
+#Preview("절단 케이스 모음") {
+    let font = UIFont(name: "Pretendard-Regular", size: 16) ?? .systemFont(ofSize: 16)
+    let reserved: CGFloat = 56
+
+    func row(_ title: String, _ text: String) -> some View {
+        let result = LogTextTruncationAnalyzer.analyze(
+            text: text, font: font, width: UIScreen.main.bounds.width - 40,
+            reservedTailWidth: reserved, lineLimit: 2
+        )
+        return VStack(alignment: .leading, spacing: 4) {
+            Text(title).font(.caption).foregroundStyle(.secondary)
+            CollapsibleLogTextView(
+                text: text,
+                font: font,
+                textColor: .label,
+                lineLimit: 2,
+                reservedTailWidth: result.isTruncated ? reserved : 0,
+                showsEllipsis: result.isTruncated && !result.lastVisibleLineEndsWithNewline
+            )
+            .background(Color(.systemGray6))
+            Text("truncated=\(String(result.isTruncated)) newlineEnd=\(String(result.lastVisibleLineEndsWithNewline))")
+                .font(.caption2).foregroundStyle(.blue)
+        }
+    }
+
+    return VStack(alignment: .leading, spacing: 20) {
+        row("① 짧은 글 (버튼 없음)", "오늘 날씨가 정말 좋았다.")
+        row("② 자연 줄바꿈 2줄 꽉 + 초과", String(repeating: "아", count: 80))
+        row("③ 엔터로 중간 종료 + 가려진 줄", "오전 11:40\n오전 11:40\n숨겨진 셋째 줄 내용입니다")
+        row("④ 최대 길이 경계", String(repeating: "가나다라 ", count: 12))
+    }
+    .padding(20)
+}

--- a/VibeTrip/Shared/Components/Representables/CollapsibleLogTextView.swift
+++ b/VibeTrip/Shared/Components/Representables/CollapsibleLogTextView.swift
@@ -78,14 +78,17 @@ enum LogTextTruncationAnalyzer {
         width: CGFloat,
         exclusion: CGRect?
     ) -> Int {
-        let (manager, _) = makeLayoutManager(text: text, font: font, width: width, exclusion: exclusion)
-        var count = 0
-        manager.enumerateLineFragments(
-            forGlyphRange: NSRange(location: 0, length: manager.numberOfGlyphs)
-        ) { _, _, _, _, _ in
-            count += 1
+        let (manager, storage) = makeLayoutManager(text: text, font: font, width: width, exclusion: exclusion)
+        // NSLayoutManager는 storage를 강참조하지 않으므로 측정 동안 수명 유지
+        return withExtendedLifetime(storage) {
+            var count = 0
+            manager.enumerateLineFragments(
+                forGlyphRange: NSRange(location: 0, length: manager.numberOfGlyphs)
+            ) { _, _, _, _, _ in
+                count += 1
+            }
+            return count
         }
-        return count
     }
 
     // lineLimit번째 줄의 문자 범위 마지막 글자가 개행인지 검사

--- a/VibeTrip/Shared/Components/Representables/CollapsibleLogTextView.swift
+++ b/VibeTrip/Shared/Components/Representables/CollapsibleLogTextView.swift
@@ -48,13 +48,18 @@ enum LogTextTruncationAnalyzer {
 
     // MARK: Layout helpers
 
+    // 편집 페이지(GrowingTextEditor)와 동일한 문단 스타일 -> 한글 줄바꿈 규칙 일치
+    static func paragraphStyle() -> NSParagraphStyle {
+        NSMutableParagraphStyle()
+    }
+
     private static func makeLayoutManager(
         text: String,
         font: UIFont,
         width: CGFloat,
         exclusion: CGRect?
     ) -> (manager: NSLayoutManager, storage: NSTextStorage) {
-        let storage = NSTextStorage(string: text, attributes: [.font: font])
+        let storage = NSTextStorage(string: text, attributes: [.font: font, .paragraphStyle: paragraphStyle()])
         let container = NSTextContainer(
             size: CGSize(width: width, height: .greatestFiniteMagnitude)
         )
@@ -145,9 +150,36 @@ struct CollapsibleLogTextView: UIViewRepresentable {
     let text: String
     let font: UIFont
     let textColor: UIColor
-    let lineLimit: Int
+    let lineLimit: Int              // 0이면 전체 표시(펼침)
     let reservedTailWidth: CGFloat // 마지막 줄 우측에 비워둘 버튼 예약 폭 (0이면 예약/절단 없음)
     let showsEllipsis: Bool        // 예약 영역에 닿아 잘릴 때 말줄임(…)을 붙일지
+    // 펼침 상태에서 "접기" 버튼 자리를 마지막 줄에 확보하기 위한 투명 예약 텍스트
+    var trailingReserveText: String = ""
+
+    // 예약 영역에 닿아 잘릴 때만 말줄임, 줄바꿈으로 끝난 경우는 그냥 클립
+    private var lineBreakMode: NSLineBreakMode {
+        (reservedTailWidth > 0 && showsEllipsis) ? .byTruncatingTail : .byWordWrapping
+    }
+
+    // 편집 페이지(GrowingTextEditor)와 동일한 문단 스타일로 한글 줄바꿈 규칙을 맞춘다.
+    // (줄간격은 줄바꿈 위치와 무관하므로 적용하지 않음)
+    private func makeAttributedText() -> NSAttributedString {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineBreakMode = lineBreakMode
+        let result = NSMutableAttributedString(string: text, attributes: [
+            .font: font,
+            .foregroundColor: textColor,
+            .paragraphStyle: paragraph
+        ])
+        if !trailingReserveText.isEmpty {
+            result.append(NSAttributedString(string: trailingReserveText, attributes: [
+                .font: font,
+                .foregroundColor: UIColor.clear,
+                .paragraphStyle: paragraph
+            ]))
+        }
+        return result
+    }
 
     // MARK: - UIViewRepresentable
 
@@ -168,11 +200,10 @@ struct CollapsibleLogTextView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UITextView, context: Context) {
-        // 기본 속성만 갱신 -> 너비 의존적인 예약/줄바꿈 설정은 sizeThatFits에서 처리
-        if uiView.text != text { uiView.text = text }
-        uiView.font = font
-        uiView.textColor = textColor
+        // 기본 속성만 갱신 -> 너비 의존적인 예약 영역은 sizeThatFits에서 처리
+        uiView.attributedText = makeAttributedText()
         uiView.textContainer.maximumNumberOfLines = lineLimit
+        uiView.textContainer.lineBreakMode = lineBreakMode
     }
 
     // 최종 너비를 알 수 있는 시점에 예약 영역/줄바꿈 모드를 확정하고 높이를 계산
@@ -186,14 +217,12 @@ struct CollapsibleLogTextView: UIViewRepresentable {
     // MARK: - Helpers
 
     private func configure(_ textView: UITextView, width: CGFloat) {
-        if textView.text != text { textView.text = text }
-        textView.font = font
-        textView.textColor = textColor
+        textView.attributedText = makeAttributedText()
         textView.textContainer.maximumNumberOfLines = lineLimit
+        textView.textContainer.lineBreakMode = lineBreakMode
 
         guard reservedTailWidth > 0 else {
             textView.textContainer.exclusionPaths = []
-            textView.textContainer.lineBreakMode = .byWordWrapping
             return
         }
 
@@ -205,8 +234,6 @@ struct CollapsibleLogTextView: UIViewRepresentable {
             height: lineHeight
         )
         textView.textContainer.exclusionPaths = [UIBezierPath(rect: reservedRect)]
-        // 예약 영역에 닿아 잘릴 때만 말줄임, 줄바꿈으로 끝난 경우는 그냥 클립
-        textView.textContainer.lineBreakMode = showsEllipsis ? .byTruncatingTail : .byWordWrapping
     }
 }
 

--- a/VibeTripTests/LogTextTruncationAnalyzerTests.swift
+++ b/VibeTripTests/LogTextTruncationAnalyzerTests.swift
@@ -1,0 +1,45 @@
+//
+//  LogTextTruncationAnalyzerTests.swift
+//  VibeTripTests
+//
+//  Created by CHOI on 6/5/26.
+//
+
+import XCTest
+import UIKit
+@testable import VibeTrip
+
+final class LogTextTruncationAnalyzerTests: XCTestCase {
+
+    private let font = UIFont.systemFont(ofSize: 16)
+    private let width: CGFloat = 335
+    private let reserved: CGFloat = 56
+    private let lineLimit = 2
+
+    private func analyze(_ text: String) -> LogTextTruncationAnalyzer.Result {
+        LogTextTruncationAnalyzer.analyze(
+            text: text, font: font, width: width,
+            reservedTailWidth: reserved, lineLimit: lineLimit
+        )
+    }
+
+    // 짧은 글: 잘림 없음 -> 버튼 없음
+    func test_shortText_notTruncated() {
+        let r = analyze("오늘 날씨 좋다")
+        XCTAssertFalse(r.isTruncated)
+    }
+
+    // 자연 줄바꿈으로 3줄 이상: 잘림 + 마지막 줄은 줄바꿈으로 끝나지 않음(말줄임 표시)
+    func test_longWrappedText_truncated_noNewlineEnd() {
+        let r = analyze(String(repeating: "가나다라마바사 ", count: 12))
+        XCTAssertTrue(r.isTruncated)
+        XCTAssertFalse(r.lastVisibleLineEndsWithNewline)
+    }
+
+    // 엔터로 줄2 중간 종료 + 가려진 줄3: 잘림 + 마지막 줄이 줄바꿈으로 끝남(말줄임 생략)
+    func test_newlineBrokenText_truncated_newlineEnd() {
+        let r = analyze("첫째 줄\n둘째 줄\n셋째 줄은 가려진다")
+        XCTAssertTrue(r.isTruncated)
+        XCTAssertTrue(r.lastVisibleLineEndsWithNewline)
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용
- 로그 본문 텍스트가 최대 길이일 경우 더보기 버튼이 미표시되는 오류
- 더 보기 버튼으로 본문 펼쳤을 때 접기 버튼과 최상단 버튼이 겹치는 오류

## 🔗 관련 이슈
Closes #138 

## ✅ 체크리스트
- [ ] 
