### PR TITLE
chore(#151): GA 커스텀 이벤트 정확도 개선

### DIFF
--- a/VibeTrip.xcodeproj/project.pbxproj
+++ b/VibeTrip.xcodeproj/project.pbxproj
@@ -511,7 +511,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -553,7 +553,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/VibeTrip/App/MainTabBarView.swift
+++ b/VibeTrip/App/MainTabBarView.swift
@@ -280,6 +280,8 @@ struct MainTabBarView: View {
                         isAlbumCreating = false
                         albumLoadingError = nil
                         creatingAlbumId = albumId
+                        // 생성 요청한 앨범으로 등록 -> 준비 완료 시 album_create_complete 전송 대상
+                        mainPageViewModel.markPendingCreate(albumId: albumId)
                         // 푸시 미수신/지연 대비: 생성 요청한 앨범 완료 감시 바로 시작
                         Task { await mainPageViewModel.handleAlbumCompleted(albumId: albumId) }
                     },

--- a/VibeTrip/App/VibeTripApp.swift
+++ b/VibeTrip/App/VibeTripApp.swift
@@ -25,6 +25,8 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 
     // FCM FAILED 수신 시 음악 생성 실패 추적용
     private let analytics: AnalyticsServiceProtocol = FirebaseAnalyticsService()
+    // album_create_fail 이중 전송 방지 (willPresent + didReceive 동일 알림 수신 시)
+    private var firedCreateFailAlbumIds: Set<Int> = []
 
     // appState 설정 전에 수신된 콜백 신호를 버퍼링하기 위한 프로퍼티
     private struct PendingReceivePayload {
@@ -119,10 +121,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         let payload = FCMPayload.decode(from: userInfo)
         // 음악 생성 단계 실패 추적 -> Suno API 결과 FCM FAILED 수신
         if payload?.type == "FAILED" {
-            analytics.log(.albumCreateFail, parameters: [
-                .step: AnalyticsStep.musicGeneration.rawValue,
-                .errorType: Constants.musicGenerationFailedErrorType
-            ])
+            logAlbumCreateFailIfNeeded(payload: payload)
         }
         Task { @MainActor in
             appState?.needsNotificationRefresh = true
@@ -141,7 +140,11 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                                 didReceive response: UNNotificationResponse,
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
         let userInfo = response.notification.request.content.userInfo
-        let navigationAction = FCMPayload.decode(from: userInfo)?.toNavigationAction()
+        let payload = FCMPayload.decode(from: userInfo)
+        if payload?.type == "FAILED" {
+            logAlbumCreateFailIfNeeded(payload: payload)
+        }
+        let navigationAction = payload?.toNavigationAction()
         if let appState {
             Task { @MainActor in
                 appState.needsNotificationRefresh = true
@@ -151,6 +154,21 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
             pendingReceivePayload = PendingReceivePayload(navigationAction: navigationAction)
         }
         completionHandler()
+    }
+
+    // MARK: - Analytics
+
+    // 음악 생성 실패 이벤트 전송 (albumId 기반 이중 전송 방지)
+    private func logAlbumCreateFailIfNeeded(payload: FCMPayload?) {
+        let albumId = payload?.error?.data?.albumId ?? payload?.data?.albumId
+        if let albumId {
+            guard !firedCreateFailAlbumIds.contains(albumId) else { return }
+            firedCreateFailAlbumIds.insert(albumId)
+        }
+        analytics.log(.albumCreateFail, parameters: [
+            .step: AnalyticsStep.musicGeneration.rawValue,
+            .errorType: Constants.musicGenerationFailedErrorType
+        ])
     }
 }
 

--- a/VibeTrip/Features/Album/ViewModels/MainPageViewModel.swift
+++ b/VibeTrip/Features/Album/ViewModels/MainPageViewModel.swift
@@ -58,6 +58,8 @@ final class MainPageViewModel: ObservableObject {
     private var pollingTasks: [Int: Task<Void, Never>] = [:]
     // 음악 생성 완료된 앨범 ID 집합 (재조회 시 유지 -> 이미 준비된 앨범 스켈레톤 방지)
     private var readyAlbumIds: Set<Int> = []
+    // 이번 실행에서 생성 요청한 앨범 ID 집합 (album_create_complete 전송 대상 한정)
+    private var pendingCreateAlbumIds: Set<Int> = []
     // 폴링 간격 (기본 5초, 테스트 시 0으로 주입 가능)
     private let pollingInterval: UInt64
 
@@ -130,6 +132,11 @@ final class MainPageViewModel: ObservableObject {
     // 음악 생성 완료 여부
     func isReady(for albumId: Int) -> Bool {
         readyAlbumIds.contains(albumId)
+    }
+
+    // 생성 요청한 앨범 등록 -> 해당 앨범 준비 완료 시에만 album_create_complete 전송
+    func markPendingCreate(albumId: Int) {
+        pendingCreateAlbumIds.insert(albumId)
     }
 
     // 결과: albums 배열에 누적, 완료 후 musicUrl 미준비 앨범 폴링 시작
@@ -251,10 +258,7 @@ final class MainPageViewModel: ObservableObject {
     }
 
     // 음악 생성 완료 시: title 업데이트 + readyAlbumIds 등록 + 폴링 Task 정리
-    // FCM + 폴링이 모두 도달해도 album_create_complete가 한 번만 전송되도록 readyAlbumIds 가드 사용
     private func applyAlbumReady(detail: AlbumDetail, for albumId: Int) {
-        let alreadyReady = readyAlbumIds.contains(albumId)
-
         if let title = detail.title, let idx = albums.firstIndex(where: { $0.id == albumId }) {
             let old = albums[idx]
             albums[idx] = AlbumCard(
@@ -272,8 +276,9 @@ final class MainPageViewModel: ObservableObject {
         pollingTasks[albumId] = nil
         lastCompletedAlbumId = albumId
 
-        // 앨범 생성 완료 추적 (FCM + 폴링 양 경로의 수렴점, albumId 단위 1회 전송)
-        guard !alreadyReady else { return }
+        // 앨범 생성 완료 추적: 이번 실행에서 생성 요청한 앨범만 1회 전송
+        // 앱 재시작 후 기존 완료 앨범 재감지·수정 후 음악 재생성 완료는 제외
+        guard pendingCreateAlbumIds.remove(albumId) != nil else { return }
         analytics.log(.albumCreateComplete, parameters: [
             .genre: detail.genre?.serverValue ?? "unknown",
             .hasLyrics: detail.withLyrics,

--- a/VibeTrip/Features/Album/ViewModels/MainPageViewModel.swift
+++ b/VibeTrip/Features/Album/ViewModels/MainPageViewModel.swift
@@ -127,6 +127,7 @@ final class MainPageViewModel: ObservableObject {
     // 앨범 수정 완료 후 해당 앨범을 미준비 상태로 전환 -> 폴링 재시작 대상
     func markAlbumNotReady(albumId: Int) {
         readyAlbumIds.remove(albumId)
+        pendingCreateAlbumIds.remove(albumId)
     }
 
     // 음악 생성 완료 여부

--- a/VibeTrip/Shared/Components/Modifiers/ScreenViewModifier.swift
+++ b/VibeTrip/Shared/Components/Modifiers/ScreenViewModifier.swift
@@ -29,9 +29,12 @@ extension EnvironmentValues {
 private struct ScreenViewModifier: ViewModifier {
     let screenName: String
     @Environment(\.analytics) private var analytics
+    @State private var hasLogged = false
 
     func body(content: Content) -> some View {
         content.onAppear {
+            guard !hasLogged else { return }
+            hasLogged = true
             analytics.log(.screenView, parameters: [.screenName: screenName])
         }
     }

--- a/VibeTripTests/MainPageViewModelTests.swift
+++ b/VibeTripTests/MainPageViewModelTests.swift
@@ -512,7 +512,7 @@ final class MainPageViewModelTests: XCTestCase {
 
     // MARK: - Analytics
 
-    // 폴링 완료(applyAlbumReady) 시 album_create_complete가 1회 기록되는지 검증
+    // 생성 요청 등록 후 폴링 완료 시 album_create_complete가 1회 전송되는지 검증
     func test_polling_complete_logsAlbumCreateComplete() async {
         let nilAlbum = AlbumCard(id: 10, title: nil, location: "제주", startDate: "2026-01-01", endDate: "2026-01-03", coverImageUrl: nil)
         let stub = PollingStubAlbumService(albums: [nilAlbum])
@@ -521,6 +521,7 @@ final class MainPageViewModelTests: XCTestCase {
         sut = MainPageViewModel(albumService: stub, pollingInterval: 0,
                                 notificationAuthorizationChecker: { .denied },
                                 analytics: analytics)
+        sut.markPendingCreate(albumId: 10)
 
         await sut.loadAlbums()
         try? await Task.sleep(nanoseconds: 10_000_000)
@@ -529,8 +530,26 @@ final class MainPageViewModelTests: XCTestCase {
         XCTAssertEqual(analytics.loggedEvents.first?.event, .albumCreateComplete)
     }
 
-    // 같은 앨범에 대해 FCM과 폴링이 모두 도달해도 album_create_complete는 1회만 기록되는지 검증
+    // 같은 앨범에 대해 FCM과 폴링이 모두 도달해도 album_create_complete는 1회만 전송되는지 검증
     func test_applyAlbumReady_duplicateInvocation_logsOnce() async {
+        let nilAlbum = AlbumCard(id: 10, title: nil, location: "제주", startDate: "2026-01-01", endDate: "2026-01-03", coverImageUrl: nil)
+        let stub = PollingStubAlbumService(albums: [nilAlbum])
+        stub.titleReadyAfterAttempts = 1
+        let analytics = MockAnalyticsService()
+        sut = MainPageViewModel(albumService: stub, pollingInterval: 0,
+                                notificationAuthorizationChecker: { .denied },
+                                analytics: analytics)
+        sut.markPendingCreate(albumId: 10)
+
+        await sut.loadAlbums()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        await sut.handleAlbumCompleted(albumId: 10)
+
+        XCTAssertEqual(analytics.loggedEvents.count, 1)
+    }
+
+    // 생성 요청 미등록 시 완료돼도 album_create_complete 미전송 (앱 재시작 시나리오)
+    func test_albumReady_withoutPendingCreate_doesNotLog() async {
         let nilAlbum = AlbumCard(id: 10, title: nil, location: "제주", startDate: "2026-01-01", endDate: "2026-01-03", coverImageUrl: nil)
         let stub = PollingStubAlbumService(albums: [nilAlbum])
         stub.titleReadyAfterAttempts = 1
@@ -541,9 +560,47 @@ final class MainPageViewModelTests: XCTestCase {
 
         await sut.loadAlbums()
         try? await Task.sleep(nanoseconds: 10_000_000)
-        // FCM이 뒤늦게 도착해도 readyAlbumIds 가드에 의해 추가 기록 없음
+
+        XCTAssertTrue(analytics.loggedEvents.isEmpty)
+    }
+
+    // 전송 후 재완료(수정 재생성) 시 추가 전송 없음
+    func test_albumReady_afterAlreadyFired_doesNotLogAgain() async {
+        let nilAlbum = AlbumCard(id: 10, title: nil, location: "제주", startDate: "2026-01-01", endDate: "2026-01-03", coverImageUrl: nil)
+        let stub = PollingStubAlbumService(albums: [nilAlbum])
+        stub.titleReadyAfterAttempts = 1
+        let analytics = MockAnalyticsService()
+        sut = MainPageViewModel(albumService: stub, pollingInterval: 0,
+                                notificationAuthorizationChecker: { .denied },
+                                analytics: analytics)
+        sut.markPendingCreate(albumId: 10)
+
+        await sut.loadAlbums()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        XCTAssertEqual(analytics.loggedEvents.count, 1)
+
+        // 수정 재생성 시뮬레이션: 미준비 전환 후 재완료
+        sut.markAlbumNotReady(albumId: 10)
         await sut.handleAlbumCompleted(albumId: 10)
 
         XCTAssertEqual(analytics.loggedEvents.count, 1)
+    }
+
+    // markAlbumNotReady 호출 후 완료 시 album_create_complete 미전송
+    func test_markAlbumNotReady_removesPendingCreate() async {
+        let nilAlbum = AlbumCard(id: 10, title: nil, location: "제주", startDate: "2026-01-01", endDate: "2026-01-03", coverImageUrl: nil)
+        let stub = PollingStubAlbumService(albums: [nilAlbum])
+        stub.titleReadyAfterAttempts = 1
+        let analytics = MockAnalyticsService()
+        sut = MainPageViewModel(albumService: stub, pollingInterval: 0,
+                                notificationAuthorizationChecker: { .denied },
+                                analytics: analytics)
+        sut.markPendingCreate(albumId: 10)
+        sut.markAlbumNotReady(albumId: 10)
+
+        await sut.loadAlbums()
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        XCTAssertTrue(analytics.loggedEvents.isEmpty)
     }
 }


### PR DESCRIPTION
## 📄 작업 내용
Google Analytics 커스텀 이벤트 정확도 개선

## 📝 변경 사항
- `album_create_complete` 오전송 수정
- 앨범 수정 후 음악 재생성 완료 시 `album_edit_complete`와 함께 `album_create_complete`도 전송되던 문제 수정
- 생성 실패 앨범의 수정 및 재생성 시 오전송 방어 처리 추가

## 🔗 관련 이슈
Closes #151 

## ✅ 체크리스트
- [ ] 
