### PR TITLE
fix(#155): 로그인 화면 체류 시간에 대한 오탐 타임아웃

### DIFF
--- a/VibeTrip/Core/Auth/AppleAuthService.swift
+++ b/VibeTrip/Core/Auth/AppleAuthService.swift
@@ -16,49 +16,23 @@ import UIKit
 
 final class AppleAuthService: NSObject, AppleAuthServiceProtocol {
 
-    private enum Constants {
-        static let timeoutSeconds: UInt64 = 10
-    }
-
     private var continuation: CheckedContinuation<(identityToken: String, fullName: String?), Error>?
     // ASAuthorizationController를 강한 참조로 유지 (auth 완료 전 해제 방지)
     private var controller: ASAuthorizationController?
 
+    // delegate 콜백(성공/취소/실패) 대기 -> 네트워크 타임아웃은 백엔드 통신 구간에서 담당.
     func login() async throws -> (identityToken: String, fullName: String?) {
-        return try await withThrowingTaskGroup(of: (identityToken: String, fullName: String?).self) { group in
-            // 애플 로그인 작업
-            group.addTask {
-                try await withTaskCancellationHandler {
-                    try await withCheckedThrowingContinuation { continuation in
-                        self.continuation = continuation
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
 
-                        let request = ASAuthorizationAppleIDProvider().createRequest()
-                        request.requestedScopes = [.fullName, .email]
+            let request = ASAuthorizationAppleIDProvider().createRequest()
+            request.requestedScopes = [.fullName, .email]
 
-                        let controller = ASAuthorizationController(authorizationRequests: [request])
-                        controller.delegate = self
-                        controller.presentationContextProvider = self
-                        self.controller = controller
-                        controller.performRequests()
-                    }
-                } onCancel: {
-                    // 타임아웃으로 취소 시 저장된 continuation 정리
-                    self.continuation?.resume(throwing: LoginError.cancelled)
-                    self.continuation = nil
-                    self.controller = nil
-                }
-            }
-
-            // 타임아웃: 10초 초과 시 LoginError.timeout throw
-            group.addTask {
-                try await Task.sleep(nanoseconds: Constants.timeoutSeconds * 1_000_000_000)
-                throw LoginError.timeout
-            }
-
-            // 먼저 완료된 결과 반환 후 나머지 취소
-            let (identityToken, fullName) = try await group.next()!
-            group.cancelAll()
-            return (identityToken, fullName)
+            let controller = ASAuthorizationController(authorizationRequests: [request])
+            controller.delegate = self
+            controller.presentationContextProvider = self
+            self.controller = controller
+            controller.performRequests()
         }
     }
 }

--- a/VibeTrip/Core/Auth/KakaoAuthService.swift
+++ b/VibeTrip/Core/Auth/KakaoAuthService.swift
@@ -17,40 +17,21 @@ import KakaoSDKUser
 
 final class KakaoAuthService: KakaoAuthServiceProtocol {
 
-    private enum Constants {
-        static let timeoutSeconds: UInt64 = 10
-    }
-
+    // SDK 콜백(성공/취소/실패) 대기한다 -> 네트워크 타임아웃은 백엔드 통신 구간에서 담당
     func login() async throws -> String {
-        return try await withThrowingTaskGroup(of: String.self) { group in
-            // 카카오 로그인 작업
-            group.addTask {
-                try await withCheckedThrowingContinuation { continuation in
-                    // 카카오톡 앱 설치 여부에 따라 분기
-                    if UserApi.isKakaoTalkLoginAvailable() {
-                        // 앱 로그인
-                        UserApi.shared.loginWithKakaoTalk { oauthToken, error in
-                            continuation.resume(with: self.handle(oauthToken: oauthToken, error: error))
-                        }
-                    } else {
-                        // 웹 로그인
-                        UserApi.shared.loginWithKakaoAccount { oauthToken, error in
-                            continuation.resume(with: self.handle(oauthToken: oauthToken, error: error))
-                        }
-                    }
+        try await withCheckedThrowingContinuation { continuation in
+            // 카카오톡 앱 설치 여부에 따라 분기
+            if UserApi.isKakaoTalkLoginAvailable() {
+                // 앱 로그인
+                UserApi.shared.loginWithKakaoTalk { oauthToken, error in
+                    continuation.resume(with: self.handle(oauthToken: oauthToken, error: error))
+                }
+            } else {
+                // 웹 로그인
+                UserApi.shared.loginWithKakaoAccount { oauthToken, error in
+                    continuation.resume(with: self.handle(oauthToken: oauthToken, error: error))
                 }
             }
-
-            // 타임아웃: 10초 초과 시 LoginError.timeout throw
-            group.addTask {
-                try await Task.sleep(nanoseconds: Constants.timeoutSeconds * 1_000_000_000)
-                throw LoginError.timeout
-            }
-
-            // 먼저 완료된 결과 반환 후 나머지 취소
-            let result = try await group.next()!
-            group.cancelAll()
-            return result
         }
     }
     

--- a/VibeTrip/Features/Auth/ViewModels/LoginViewModel.swift
+++ b/VibeTrip/Features/Auth/ViewModels/LoginViewModel.swift
@@ -99,8 +99,10 @@ final class LoginViewModel: ObservableObject {
                     .compactMap { $0 }
                 let fullName: String? = nameParts.isEmpty ? nil : nameParts.joined(separator: " ")
 
+                #if DEBUG
                 print("애플 identityToken: \(identityToken)")
                 print("애플 fullName: \(fullName ?? "null")")
+                #endif
 
                 try await performBackendAuth(token: identityToken, provider: .apple, fullName: fullName)
 
@@ -154,7 +156,9 @@ final class LoginViewModel: ObservableObject {
         do {
             /// 카카오 토큰 획득
             let token = try await kakaoAuthService.login()
+            #if DEBUG
             print("카카오 accessToken: \(token)")
+            #endif
             try await performBackendAuth(token: token, provider: .kakao)
         } catch let loginError as LoginError {
             if case .cancelled = loginError { return }
@@ -171,8 +175,10 @@ final class LoginViewModel: ObservableObject {
 
         do {
             let (identityToken, fullName) = try await appleAuthService.login()
+            #if DEBUG
             print("애플 identityToken: \(identityToken)")
             print("애플 fullName: \(fullName ?? "null")")
+            #endif
             try await performBackendAuth(token: identityToken, provider: .apple, fullName: fullName)
         } catch let loginError as LoginError {
             /// 취소: 에러 UI 없이 그대로 로그인 화면 유지
@@ -192,9 +198,11 @@ final class LoginViewModel: ObservableObject {
     private func performBackendAuth(token: String, provider: LoginProvider, fullName: String? = nil) async throws {
         let deviceId = UIDevice.current.identifierForVendor?.uuidString ?? ""
         let fcmToken = await fetchFCMToken()
+        #if DEBUG
         print("deviceId: \(deviceId)")
         print("fcmToken: \(fcmToken)")
         print("백엔드 요청. provider: \(provider.rawValue)")
+        #endif
 
         let authToken = try await backendAuthService.authenticate(
             token: token,


### PR DESCRIPTION
## 📄 작업 내용
소셜 로그인 진행 중 사용자가 카카오 계정 로그인에 소요하는 시간이 응답 지연으로 오인되어 타임아웃 팝업이 표시되던 문제 해결

## 📝 변경 사항
- 애플: delegate 콜백 결과를 그대로 대기하도록 변경
- 카카오: SDK 콜백 결과를 그대로 대기하도록 변경 및 네트워크 타임아웃은 서버 통신 구간에서만 담당하도록 책임 분리

## 🔗 관련 이슈
Closes #155 

## ✅ 체크리스트
- [ ] 소셜 로그인 진행을 10초 이상 진행해도 타임아웃 팝업이 표시 안되는가?
